### PR TITLE
fix(ahwr-1664): Link is to name, not id, on the macro radio #patch

### DIFF
--- a/app/routes/select-funding.js
+++ b/app/routes/select-funding.js
@@ -47,7 +47,7 @@ export const selectFundingRouteHandlers = [
     options: {
       validate: {
         payload: Joi.object({
-          type: Joi.string()
+          fundingType: Joi.string()
             .valid("IAHW", "POUL")
             .required()
             .messages({ "any.required": "Select a funding" }),
@@ -80,7 +80,7 @@ export const selectFundingRouteHandlers = [
               }),
               errorMessage: {
                 text: error.details[0].message,
-                href: "#selectFunding",
+                href: "#fundingType",
               },
             })
             .code(HttpStatus.BAD_REQUEST)
@@ -89,16 +89,16 @@ export const selectFundingRouteHandlers = [
       },
       handler: async (request, h) => {
         clearFundingSelection(request);
-        const { type } = request.payload;
+        const { fundingType } = request.payload;
 
         await setSessionData(
           request,
           sessionEntryKeys.fundingSelection,
           sessionKeys.fundingSelection.selectedFunding,
-          type,
+          fundingType,
         );
 
-        if (type === "IAHW") {
+        if (fundingType === "IAHW") {
           const latestEndemicsApplication = getSessionData(
             request,
             sessionEntryKeys.endemicsClaim,
@@ -117,7 +117,7 @@ export const selectFundingRouteHandlers = [
           );
         }
 
-        if (type === "POUL") {
+        if (fundingType === "POUL") {
           const latestPoultryApplication = getSessionData(
             request,
             sessionEntryKeys.poultryClaim,

--- a/app/views/select-funding.njk
+++ b/app/views/select-funding.njk
@@ -28,8 +28,8 @@
       <input type="hidden" name="crumb" value="{{crumb}}" />
 
       {{ govukRadios({
-        id: "selectFunding",
-        name: "type",
+        id: "fundingType",
+        name: "fundingType",
         errorMessage: errorMessage,
         fieldset: {
           legend: {

--- a/test/integration/narrow/routes/select-funding.test.js
+++ b/test/integration/narrow/routes/select-funding.test.js
@@ -105,7 +105,7 @@ describe("select-funding", () => {
       expect(await axe(res.payload)).toHaveNoViolations();
       const $ = cheerio.load(res.payload);
       expect($("h1").text()).toMatch("Select funding");
-      expect($('input[name="type"]').first().next("label").text().trim()).toBe(
+      expect($('input[name="fundingType"]').first().next("label").text().trim()).toBe(
         "Cattle, pig, and sheep review and follow-up",
       );
       expect($(".govuk-radios__hint").first().text().trim()).toBe(
@@ -119,7 +119,7 @@ describe("select-funding", () => {
       expect(await axe(res.payload)).toHaveNoViolations();
       const $ = cheerio.load(res.payload);
       expect($("h1").text()).toMatch("Select funding");
-      expect($('input[name="type"]').eq(1).next("label").text().trim()).toBe(
+      expect($('input[name="fundingType"]').eq(1).next("label").text().trim()).toBe(
         "Poultry biosecurity review",
       );
       expect($(".govuk-radios__hint").eq(1).text().trim()).toBe(
@@ -140,7 +140,7 @@ describe("select-funding", () => {
       expect(await axe(res.payload)).toHaveNoViolations();
       const $ = cheerio.load(res.payload);
       expect($("h1").text()).toMatch("Select funding");
-      expect($('input[name="type"]').first().next("label").text().trim()).toBe(
+      expect($('input[name="fundingType"]').first().next("label").text().trim()).toBe(
         "Cattle, pig, and sheep review and follow-up",
       );
       expect($(".govuk-radios__hint").first().text().trim()).toBe(
@@ -162,7 +162,7 @@ describe("select-funding", () => {
       expect(await axe(res.payload)).toHaveNoViolations();
       const $ = cheerio.load(res.payload);
       expect($("h1").text()).toMatch("Select funding");
-      expect($('input[name="type"]').eq(1).next("label").text().trim()).toBe(
+      expect($('input[name="fundingType"]').eq(1).next("label").text().trim()).toBe(
         "Poultry biosecurity review",
       );
       expect($(".govuk-radios__hint").eq(1).text().trim()).toBe(
@@ -235,7 +235,7 @@ describe("select-funding", () => {
         ...postOptionsBase,
         payload: {
           ...postOptionsBase.payload,
-          type: "IAHW",
+          fundingType: "IAHW",
         },
       };
 
@@ -271,7 +271,7 @@ describe("select-funding", () => {
         ...postOptionsBase,
         payload: {
           ...postOptionsBase.payload,
-          type: "IAHW",
+          fundingType: "IAHW",
         },
       };
 
@@ -307,7 +307,7 @@ describe("select-funding", () => {
         ...postOptionsBase,
         payload: {
           ...postOptionsBase.payload,
-          type: "POUL",
+          fundingType: "POUL",
         },
       };
 
@@ -343,7 +343,7 @@ describe("select-funding", () => {
         ...postOptionsBase,
         payload: {
           ...postOptionsBase.payload,
-          type: "POUL",
+          fundingType: "POUL",
         },
       };
 


### PR DESCRIPTION
The link for the radio button is linked to the name on the macro, not to the id.