### PR TITLE
fix(ahwr-1801): avoiding getting the context on error-pages #patch

### DIFF
--- a/app/plugins/view-context.js
+++ b/app/plugins/view-context.js
@@ -13,7 +13,7 @@ export const viewContextPlugin = {
       server.ext("onPreResponse", function (request, h) {
         const response = request.response;
 
-        if (response.variety === "view") {
+        if (response.variety === "view" && !response.source.template?.startsWith("error-pages/")) {
           const ctx = response.source.context || {};
 
           let serviceUrl = "/";

--- a/app/session/index.js
+++ b/app/session/index.js
@@ -220,11 +220,9 @@ export const getSessionData = (request, entryKey, key) => {
       );
     }
 
-    // If the session has expired this will throw an error
     return request.yar.get(entryKey)?.[key];
   }
 
-  // If the session has expired this will throw an error
   return request.yar.get(entryKey);
 };
 

--- a/app/session/index.js
+++ b/app/session/index.js
@@ -220,18 +220,12 @@ export const getSessionData = (request, entryKey, key) => {
       );
     }
 
-    try {
-      return request.yar.get(entryKey)?.[key];
-    } catch {
-      return undefined;
-    }
+    // If the session has expired this will throw an error
+    return request.yar.get(entryKey)?.[key];
   }
 
-  try {
-    return request.yar.get(entryKey);
-  } catch {
-    return undefined;
-  }
+  // If the session has expired this will throw an error
+  return request.yar.get(entryKey);
 };
 
 export async function clearAllOfSession(request) {

--- a/app/session/index.js
+++ b/app/session/index.js
@@ -220,10 +220,18 @@ export const getSessionData = (request, entryKey, key) => {
       );
     }
 
-    return request.yar.get(entryKey)?.[key];
+    try {
+      return request.yar.get(entryKey)?.[key];
+    } catch {
+      return undefined;
+    }
   }
 
-  return request.yar.get(entryKey);
+  try {
+    return request.yar.get(entryKey);
+  } catch {
+    return undefined;
+  }
 };
 
 export async function clearAllOfSession(request) {

--- a/test/unit/app/plugins/view-context.test.js
+++ b/test/unit/app/plugins/view-context.test.js
@@ -1,0 +1,80 @@
+import { viewContextPlugin } from "../../../../app/plugins/view-context.js";
+
+jest.mock("../../../../app/lib/context-helper.js");
+jest.mock("../../../../app/lib/agreement-helper.js");
+
+describe("View Context Plugin", () => {
+  let onPreResponseHandler;
+  const mockH = { continue: Symbol("continue") };
+
+  beforeAll(() => {
+    const mockServer = {
+      ext: (event, handler) => {
+        if (event === "onPreResponse") {
+          onPreResponseHandler = handler;
+        }
+      },
+    };
+    viewContextPlugin.plugin.register(mockServer);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("response filtering", () => {
+    it("sets context when response is a view and template does not start with error-pages/", () => {
+      const mockRequest = {
+        path: "/test",
+        auth: { isAuthenticated: true },
+        response: {
+          variety: "view",
+          source: {
+            template: "claim/check-answers",
+            context: {},
+          },
+        },
+      };
+
+      const result = onPreResponseHandler(mockRequest, mockH);
+
+      expect(result).toBe(mockH.continue);
+      expect(mockRequest.response.source.context.serviceName).toBeDefined();
+    });
+
+    it("does not set context when template starts with error-pages/", () => {
+      const mockRequest = {
+        path: "/test",
+        auth: { isAuthenticated: true },
+        response: {
+          variety: "view",
+          source: {
+            template: "error-pages/500",
+            context: {},
+          },
+        },
+      };
+
+      const result = onPreResponseHandler(mockRequest, mockH);
+
+      expect(result).toBe(mockH.continue);
+      expect(mockRequest.response.source.context.serviceName).toBeUndefined();
+    });
+
+    it("does not set context when response is not a view", () => {
+      const mockRequest = {
+        path: "/test",
+        auth: { isAuthenticated: true },
+        response: {
+          variety: "plain",
+          source: {},
+        },
+      };
+
+      const result = onPreResponseHandler(mockRequest, mockH);
+
+      expect(result).toBe(mockH.continue);
+      expect(mockRequest.response.source.context).toBeUndefined();
+    });
+  });
+});

--- a/test/unit/app/session/index.test.js
+++ b/test/unit/app/session/index.test.js
@@ -1,16 +1,22 @@
 import {
   clearAllOfSession,
   clearApplyRedirect,
+  clearFundingSelection,
+  clearEndemicsClaim,
+  clearPoultryClaim,
   sessionEntryKeys,
   removeSessionDataForSelectHerdChange,
+  removeSessionDataForSameHerdChange,
+  removeMultipleHerdsSessionData,
   setSessionEntry,
   setSessionData,
+  getSessionData,
   sessionKeys,
   emitHerdEvent,
 } from "../../../../app/session/index.js";
 import {
-  sendHerdEvent,
   sendSessionEvent,
+  sendHerdEvent,
 } from "../../../../app/messaging/session-event-emission.js";
 
 jest.mock("../../../../app/messaging/session-event-emission.js");
@@ -51,13 +57,180 @@ describe("session", () => {
 
       expect(mockDropFn).toHaveBeenCalledWith(sessionId);
     });
+
+    test("does not call cache.drop when no sessionId in credentials", async () => {
+      const mockDropFn = jest.fn();
+      const request = {
+        yar: yarMock,
+        auth: { credentials: {} },
+        server: { app: { cache: { drop: mockDropFn } } },
+      };
+      await clearAllOfSession(request);
+
+      expect(mockDropFn).not.toHaveBeenCalled();
+    });
   });
 
   describe("clearApplyRedirect", () => {
-    const request = { yar: yarMock };
-    clearApplyRedirect(request);
+    test("clears signInRedirect from session", () => {
+      const request = { yar: yarMock };
+      clearApplyRedirect(request);
 
-    expect(yarMock.clear).toHaveBeenCalledWith(sessionEntryKeys.signInRedirect);
+      expect(yarMock.clear).toHaveBeenCalledWith(sessionEntryKeys.signInRedirect);
+    });
+  });
+
+  describe("clearFundingSelection", () => {
+    test("clears fundingSelection from session", () => {
+      const request = { yar: yarMock };
+      clearFundingSelection(request);
+
+      expect(yarMock.clear).toHaveBeenCalledWith(sessionEntryKeys.fundingSelection);
+    });
+  });
+
+  describe("clearEndemicsClaim", () => {
+    test("retains only latestVetVisitApplication and latestEndemicsApplication", () => {
+      const endemicsClaim = {
+        latestVetVisitApplication: { ref: "VET-123" },
+        latestEndemicsApplication: { ref: "END-456" },
+        reference: "IAHW-G3CL-V59P",
+        typeOfLivestock: "beef",
+        dateOfVisit: "2025-08-15T00:00:00Z",
+        biosecurity: "yes",
+      };
+      const organisation = {
+        name: "Fake org name",
+        sbi: "123456789",
+      };
+
+      yarMock.get.mockImplementation((entryKey) => {
+        if (entryKey === sessionEntryKeys.endemicsClaim) {
+          return endemicsClaim;
+        }
+        if (entryKey === sessionEntryKeys.organisation) {
+          return organisation;
+        }
+        return undefined;
+      });
+
+      const request = { yar: yarMock };
+      clearEndemicsClaim(request);
+
+      expect(yarMock.set).toHaveBeenCalledWith(sessionEntryKeys.endemicsClaim, {
+        latestVetVisitApplication: { ref: "VET-123" },
+        latestEndemicsApplication: { ref: "END-456" },
+      });
+      expect(yarMock.set).toHaveBeenCalledWith(sessionEntryKeys.organisation, organisation);
+    });
+
+    test("handles undefined endemicsClaim gracefully", () => {
+      yarMock.get.mockImplementation((entryKey) => {
+        if (entryKey === sessionEntryKeys.organisation) {
+          return { name: "Org" };
+        }
+        return undefined;
+      });
+
+      const request = { yar: yarMock };
+      clearEndemicsClaim(request);
+
+      expect(yarMock.set).toHaveBeenCalledWith(sessionEntryKeys.endemicsClaim, {
+        latestVetVisitApplication: undefined,
+        latestEndemicsApplication: undefined,
+      });
+    });
+  });
+
+  describe("clearPoultryClaim", () => {
+    test("retains only latestPoultryApplication", () => {
+      const poultryClaim = {
+        latestPoultryApplication: { ref: "POUL-123" },
+        reference: "POUL-G3CL-V59P",
+        dateOfVisit: "2025-08-15T00:00:00Z",
+        biosecurity: "yes",
+        herdId: "herd-123",
+      };
+      const organisation = {
+        name: "Fake org name",
+        sbi: "123456789",
+      };
+
+      yarMock.get.mockImplementation((entryKey) => {
+        if (entryKey === sessionEntryKeys.poultryClaim) {
+          return poultryClaim;
+        }
+
+        if (entryKey === sessionEntryKeys.organisation) {
+          return organisation;
+        }
+        return undefined;
+      });
+
+      const request = { yar: yarMock };
+      clearPoultryClaim(request);
+
+      expect(yarMock.set).toHaveBeenCalledWith(sessionEntryKeys.poultryClaim, {
+        latestPoultryApplication: { ref: "POUL-123" },
+      });
+      expect(yarMock.set).toHaveBeenCalledWith(sessionEntryKeys.organisation, organisation);
+    });
+
+    test("handles undefined poultryClaim gracefully", () => {
+      yarMock.get.mockImplementation((entryKey) => {
+        if (entryKey === sessionEntryKeys.organisation) {
+          return { name: "Org" };
+        }
+        return undefined;
+      });
+
+      const request = { yar: yarMock };
+      clearPoultryClaim(request);
+
+      expect(yarMock.set).toHaveBeenCalledWith(sessionEntryKeys.poultryClaim, {
+        latestPoultryApplication: undefined,
+      });
+    });
+  });
+
+  describe("removeMultipleHerdsSessionData", () => {
+    test("clears herd-related fields from endemicsClaim", () => {
+      const endemicsClaim = {
+        latestVetVisitApplication: { ref: "VET-123" },
+        reference: "IAHW-G3CL-V59P",
+        typeOfLivestock: "beef",
+        tempHerdId: "temp-herd-123",
+        herdId: "herd-123",
+        herdName: "Main Herd",
+        herdCph: "12/345/6789",
+        isOnlyHerdOnSbi: false,
+        herdReasons: ["reason1"],
+        herdSame: "yes",
+      };
+
+      yarMock.get.mockImplementation((entryKey) => {
+        if (entryKey === sessionEntryKeys.endemicsClaim) {
+          return endemicsClaim;
+        }
+        return undefined;
+      });
+
+      const request = { yar: yarMock };
+      removeMultipleHerdsSessionData(request);
+
+      expect(yarMock.set).toHaveBeenCalledWith(sessionEntryKeys.endemicsClaim, {
+        latestVetVisitApplication: { ref: "VET-123" },
+        reference: "IAHW-G3CL-V59P",
+        typeOfLivestock: "beef",
+        tempHerdId: undefined,
+        herdId: undefined,
+        herdName: undefined,
+        herdCph: undefined,
+        isOnlyHerdOnSbi: undefined,
+        herdReasons: undefined,
+        herdSame: undefined,
+      });
+    });
   });
 
   describe("removeSessionDataForSelectHerdChange", () => {
@@ -124,6 +297,206 @@ describe("session", () => {
         originalSession: endemicsClaim,
         remadeSession: expectedSession,
       });
+    });
+  });
+
+  describe("removeSessionDataForSameHerdChange", () => {
+    test("rebuilds session and restores herd info from original", () => {
+      const endemicsClaim = {
+        latestVetVisitApplication: { a: 1 },
+        latestEndemicsApplication: { b: 2 },
+        previousClaims: [{ id: 1 }],
+        reference: "IAHW-G3CL-V59P",
+        typeOfLivestock: "beef",
+        typeOfReview: "beef",
+        dateOfVisit: "2025-08-15T00:00:00Z",
+        tempHerdId: "temp-123",
+        herds: [{ id: "herd1" }],
+        vetVisitsReviewTestResults: "negative",
+        herdId: "herd-456",
+        herdVersion: 2,
+        herdName: "Main Herd",
+        herdCph: "12/345/6789",
+        isOnlyHerdOnSbi: true,
+        herdReasons: ["reason1", "reason2"],
+        biosecurity: "yes",
+      };
+      const organisation = {
+        name: "Fake org name",
+        sbi: "123456789",
+      };
+
+      yarMock.get.mockImplementation((entryKey) => {
+        if (entryKey === sessionEntryKeys.endemicsClaim) {
+          return endemicsClaim;
+        }
+        if (entryKey === sessionEntryKeys.organisation) {
+          return organisation;
+        }
+        return undefined;
+      });
+
+      const request = { yar: yarMock };
+      removeSessionDataForSameHerdChange(request);
+
+      expect(yarMock.clear).toHaveBeenCalledWith(sessionEntryKeys.endemicsClaim);
+
+      const expectedSession = {
+        latestVetVisitApplication: { a: 1 },
+        latestEndemicsApplication: { b: 2 },
+        previousClaims: [{ id: 1 }],
+        reference: "IAHW-G3CL-V59P",
+        typeOfLivestock: "beef",
+        typeOfReview: "beef",
+        dateOfVisit: "2025-08-15T00:00:00Z",
+        tempHerdId: "temp-123",
+        herds: [{ id: "herd1" }],
+        vetVisitsReviewTestResults: "negative",
+        herdId: "herd-456",
+        herdVersion: 2,
+        herdName: "Main Herd",
+        herdCph: "12/345/6789",
+        isOnlyHerdOnSbi: true,
+        herdReasons: ["reason1", "reason2"],
+      };
+
+      expect(yarMock.set).toHaveBeenCalledWith(sessionEntryKeys.endemicsClaim, expectedSession);
+    });
+  });
+
+  describe("getSessionData", () => {
+    beforeEach(() => {
+      jest.resetAllMocks();
+    });
+
+    test("returns entire entry when no key provided", () => {
+      const endemicsClaim = {
+        reference: "IAHW-G3CL-V59P",
+        typeOfLivestock: "beef",
+      };
+
+      yarMock.get.mockImplementation((entryKey) => {
+        if (entryKey === sessionEntryKeys.endemicsClaim) {
+          return endemicsClaim;
+        }
+        return undefined;
+      });
+
+      const request = { yar: yarMock };
+      const result = getSessionData(request, sessionEntryKeys.endemicsClaim);
+
+      expect(result).toEqual(endemicsClaim);
+    });
+
+    test("returns specific key value when key provided", () => {
+      const endemicsClaim = {
+        reference: "IAHW-G3CL-V59P",
+        typeOfLivestock: "beef",
+      };
+
+      yarMock.get.mockImplementation((entryKey) => {
+        if (entryKey === sessionEntryKeys.endemicsClaim) {
+          return endemicsClaim;
+        }
+        return undefined;
+      });
+
+      const request = { yar: yarMock };
+      const result = getSessionData(
+        request,
+        sessionEntryKeys.endemicsClaim,
+        sessionKeys.endemicsClaim.reference,
+      );
+
+      expect(result).toBe("IAHW-G3CL-V59P");
+    });
+
+    test("returns undefined when entry does not exist", () => {
+      yarMock.get.mockReturnValue(undefined);
+
+      const request = { yar: yarMock };
+      const result = getSessionData(request, sessionEntryKeys.endemicsClaim);
+
+      expect(result).toBeUndefined();
+    });
+
+    test("returns undefined when key does not exist in entry", () => {
+      const endemicsClaim = {
+        reference: "IAHW-G3CL-V59P",
+      };
+
+      yarMock.get.mockImplementation((entryKey) => {
+        if (entryKey === sessionEntryKeys.endemicsClaim) {
+          return endemicsClaim;
+        }
+        return undefined;
+      });
+
+      const request = { yar: yarMock };
+      const result = getSessionData(
+        request,
+        sessionEntryKeys.endemicsClaim,
+        sessionKeys.endemicsClaim.typeOfLivestock,
+      );
+
+      expect(result).toBeUndefined();
+    });
+
+    test("throws error when entry key does not exist", () => {
+      const request = { yar: yarMock };
+
+      expect(() => {
+        getSessionData(request, "invalidEntryKey");
+      }).toThrow(
+        "Session was attempted to be accessed with an entry key that doesnt exist: invalidEntryKey.",
+      );
+    });
+
+    test("throws error when inner key does not exist in sessionKeys", () => {
+      yarMock.get.mockReturnValue({});
+
+      const request = { yar: yarMock };
+
+      expect(() => {
+        getSessionData(request, sessionEntryKeys.endemicsClaim, "invalidInnerKey");
+      }).toThrow(
+        "Session was attempted to be accessed with an inner key that doesnt exist: invalidInnerKey.",
+      );
+    });
+
+    test("allows any key for entries without nested sessionKeys definition", () => {
+      yarMock.get.mockReturnValue({ customKey: "customValue" });
+
+      const request = { yar: yarMock };
+      const result = getSessionData(request, sessionEntryKeys.organisation, "customKey");
+
+      expect(result).toBe("customValue");
+    });
+
+    test("returns undefined when yar.get throws an error (no key)", () => {
+      yarMock.get.mockImplementation(() => {
+        throw new Error("Session store is null");
+      });
+
+      const request = { yar: yarMock };
+      const result = getSessionData(request, sessionEntryKeys.endemicsClaim);
+
+      expect(result).toBeUndefined();
+    });
+
+    test("returns undefined when yar.get throws an error (with key)", () => {
+      yarMock.get.mockImplementation(() => {
+        throw new Error("Session store is null");
+      });
+
+      const request = { yar: yarMock };
+      const result = getSessionData(
+        request,
+        sessionEntryKeys.endemicsClaim,
+        sessionKeys.endemicsClaim.reference,
+      );
+
+      expect(result).toBeUndefined();
     });
   });
 
@@ -196,6 +569,33 @@ describe("session", () => {
         }
         return undefined;
       });
+    });
+
+    test("throws error when entry key does not exist", async () => {
+      const request = { yar: yarMock };
+
+      await expect(setSessionEntry(request, "invalidEntryKey", "value")).rejects.toThrow(
+        "Session entry was attempted to be set with an entry key that doesnt exist: invalidEntryKey.",
+      );
+    });
+
+    test("trims string values before setting", async () => {
+      const request = { yar: yarMock };
+      await setSessionEntry(request, sessionEntryKeys.tempReference, "  REF-123  ", {
+        shouldEmitEvent: false,
+      });
+
+      expect(yarMock.set).toHaveBeenCalledWith(sessionEntryKeys.tempReference, "REF-123");
+    });
+
+    test("does not trim non-string values", async () => {
+      const objValue = { key: "value" };
+      const request = { yar: yarMock };
+      await setSessionEntry(request, sessionEntryKeys.customer, objValue, {
+        shouldEmitEvent: false,
+      });
+
+      expect(yarMock.set).toHaveBeenCalledWith(sessionEntryKeys.customer, objValue);
     });
 
     test("emits event by default", async () => {
@@ -330,6 +730,15 @@ describe("session", () => {
         value: { name: "Farm business" },
       });
     });
+
+    test("does not emit event when no organisation in session", async () => {
+      yarMock.get.mockReturnValue(undefined);
+
+      const request = { yar: yarMock };
+      await setSessionEntry(request, sessionEntryKeys.customer, { id: "123" });
+
+      expect(sendSessionEvent).not.toHaveBeenCalled();
+    });
   });
 
   describe("setSessionData", () => {
@@ -390,6 +799,89 @@ describe("session", () => {
       address: "1 fake street,fake town,United Kingdom",
       orgEmail: "fake.org.email@example.com.test",
     };
+
+    test("throws error when entry key does not exist", async () => {
+      const request = { yar: yarMock };
+
+      await expect(setSessionData(request, "invalidEntryKey", "someKey", "value")).rejects.toThrow(
+        "Session was attempted to be set with an entry key that doesnt exist: invalidEntryKey.",
+      );
+    });
+
+    test("throws error when key is not provided", async () => {
+      const request = { yar: yarMock };
+
+      await expect(
+        setSessionData(request, sessionEntryKeys.endemicsClaim, null, "value"),
+      ).rejects.toThrow(
+        "setSessionData requires a key - use setSessionEntry for updating individual non-nested values",
+      );
+    });
+
+    test("throws error when key is undefined", async () => {
+      const request = { yar: yarMock };
+
+      await expect(
+        setSessionData(request, sessionEntryKeys.endemicsClaim, undefined, "value"),
+      ).rejects.toThrow(
+        "setSessionData requires a key - use setSessionEntry for updating individual non-nested values",
+      );
+    });
+
+    test("trims string values before setting", async () => {
+      const request = { yar: yarMock };
+      await setSessionData(
+        request,
+        sessionEntryKeys.endemicsClaim,
+        sessionKeys.endemicsClaim.vetsName,
+        "  Dr. Smith  ",
+        { shouldEmitEvent: false },
+      );
+
+      expect(yarMock.set).toHaveBeenCalledWith(sessionEntryKeys.endemicsClaim, {
+        ...endemicsClaim,
+        vetsName: "Dr. Smith",
+      });
+    });
+
+    test("does not trim non-string values", async () => {
+      const request = { yar: yarMock };
+      const arrayValue = ["item1", "item2"];
+      await setSessionData(
+        request,
+        sessionEntryKeys.endemicsClaim,
+        sessionKeys.endemicsClaim.sheepTests,
+        arrayValue,
+        { shouldEmitEvent: false },
+      );
+
+      expect(yarMock.set).toHaveBeenCalledWith(sessionEntryKeys.endemicsClaim, {
+        ...endemicsClaim,
+        sheepTests: arrayValue,
+      });
+    });
+
+    test("creates entry object if it does not exist", async () => {
+      yarMock.get.mockImplementation((entryKey) => {
+        if (entryKey === sessionEntryKeys.organisation) {
+          return organisation;
+        }
+        return undefined;
+      });
+
+      const request = { yar: yarMock };
+      await setSessionData(
+        request,
+        sessionEntryKeys.endemicsClaim,
+        sessionKeys.endemicsClaim.reference,
+        "NEW-REF-123",
+        { shouldEmitEvent: false },
+      );
+
+      expect(yarMock.set).toHaveBeenCalledWith(sessionEntryKeys.endemicsClaim, {
+        reference: "NEW-REF-123",
+      });
+    });
 
     test("emits event by default", async () => {
       const request = { yar: yarMock };
@@ -491,7 +983,6 @@ describe("session", () => {
         }
         return undefined;
       });
-
       await setSessionData(
         request,
         sessionEntryKeys.poultryClaim,
@@ -508,6 +999,40 @@ describe("session", () => {
         sbi: "123456789",
         sessionKey: "biosecurityUsefulness",
         value: "not-very-useful",
+      });
+    });
+
+    test("emits event when entryKey is farmerApplyData", async () => {
+      const request = { yar: yarMock };
+      yarMock.get.mockImplementation((entryKey) => {
+        if (entryKey === sessionEntryKeys.endemicsClaim) {
+          return endemicsClaim;
+        }
+        if (entryKey === sessionEntryKeys.organisation) {
+          return organisation;
+        }
+        if (entryKey === sessionEntryKeys.farmerApplyData) {
+          return { reference: "FARM-REF-123" };
+        }
+        return undefined;
+      });
+
+      await setSessionData(
+        request,
+        sessionEntryKeys.farmerApplyData,
+        sessionKeys.farmerApplyData.declaration,
+        true,
+      );
+
+      expect(sendSessionEvent).toHaveBeenCalledWith({
+        applicationReference: "IAHW-G3CL-V59P",
+        email: "fake.farmer.email@example.com.test",
+        id: 1,
+        journey: "farmerApplyData",
+        reference: "FARM-REF-123",
+        sbi: "123456789",
+        sessionKey: "declaration",
+        value: true,
       });
     });
 
@@ -574,7 +1099,25 @@ describe("session", () => {
     });
   });
 
+  test("does not emit event when no organisation in session", async () => {
+    yarMock.get.mockReturnValue(undefined);
+
+    const request = { yar: yarMock };
+    await setSessionData(
+      request,
+      sessionEntryKeys.endemicsClaim,
+      sessionKeys.endemicsClaim.amount,
+      "15",
+    );
+
+    expect(sendSessionEvent).not.toHaveBeenCalled();
+  });
+
   describe("emitHerdEvent", () => {
+    beforeEach(() => {
+      jest.resetAllMocks();
+    });
+
     const organisation = {
       name: "Fake org name",
       farmerName: "Fake farmer name",
@@ -609,6 +1152,72 @@ describe("session", () => {
           herdVersion: 1,
           herdName: "Herd one",
         },
+      });
+    });
+
+    test("sends herd event with organisation details", async () => {
+      const organisation = {
+        name: "Fake org name",
+        email: "fake.farmer.email@example.com.test",
+        sbi: "123456789",
+      };
+
+      yarMock.get.mockImplementation((entryKey) => {
+        if (entryKey === sessionEntryKeys.organisation) {
+          return organisation;
+        }
+        return undefined;
+      });
+
+      const request = { yar: yarMock };
+      const eventData = {
+        request,
+        type: "herd-created",
+        message: "New herd created",
+        data: { herdId: "herd-123", herdName: "Main Herd" },
+      };
+
+      await emitHerdEvent(eventData);
+
+      expect(sendHerdEvent).toHaveBeenCalledWith({
+        sbi: "123456789",
+        email: "fake.farmer.email@example.com.test",
+        sessionId: 1,
+        type: "herd-created",
+        message: "New herd created",
+        data: { herdId: "herd-123", herdName: "Main Herd" },
+      });
+    });
+
+    test("sends herd event with different event types", async () => {
+      const organisation = {
+        email: "test@example.com",
+        sbi: "987654321",
+      };
+
+      yarMock.get.mockImplementation((entryKey) => {
+        if (entryKey === sessionEntryKeys.organisation) {
+          return organisation;
+        }
+        return undefined;
+      });
+
+      const request = { yar: yarMock };
+
+      await emitHerdEvent({
+        request,
+        type: "herd-updated",
+        message: "Herd details updated",
+        data: { herdId: "herd-456" },
+      });
+
+      expect(sendHerdEvent).toHaveBeenCalledWith({
+        sbi: "987654321",
+        email: "test@example.com",
+        sessionId: 1,
+        type: "herd-updated",
+        message: "Herd details updated",
+        data: { herdId: "herd-456" },
       });
     });
   });

--- a/test/unit/app/session/index.test.js
+++ b/test/unit/app/session/index.test.js
@@ -472,32 +472,6 @@ describe("session", () => {
 
       expect(result).toBe("customValue");
     });
-
-    test("returns undefined when yar.get throws an error (no key)", () => {
-      yarMock.get.mockImplementation(() => {
-        throw new Error("Session store is null");
-      });
-
-      const request = { yar: yarMock };
-      const result = getSessionData(request, sessionEntryKeys.endemicsClaim);
-
-      expect(result).toBeUndefined();
-    });
-
-    test("returns undefined when yar.get throws an error (with key)", () => {
-      yarMock.get.mockImplementation(() => {
-        throw new Error("Session store is null");
-      });
-
-      const request = { yar: yarMock };
-      const result = getSessionData(
-        request,
-        sessionEntryKeys.endemicsClaim,
-        sessionKeys.endemicsClaim.reference,
-      );
-
-      expect(result).toBeUndefined();
-    });
   });
 
   describe("setSessionEntry", () => {


### PR DESCRIPTION
Fix exception raised when there are no endemicsClaim.

Added bunch of tests to cover the current behaviour of session/index.js