### PR TITLE
docs(AHWR-0000): fix grammar and stray period in markdown #patch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,4 +15,4 @@ By default, a commit into the trunk will cause a `minor` version increment. If y
 
 ## Integration Tests
 
-- Validate the HTML is WCAG compliant the using the assertion `toHaveNoViolations`
+- Validate the HTML is WCAG compliant using the assertion `toHaveNoViolations`

--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ and on return the authorisation is swapped out for a token that is used to retri
 
 In development environments, a dev login access point is provided that allows the use of a fixed set of details
 to simulate the authentication process without needing to interact with DefraID, meaning the UI can be developed
-and tested without relying on an external service
-.
+and tested without relying on an external service.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary
Two small documentation fixes: a grammar correction in CONTRIBUTING.md and a stray full stop on its own line in README.md that was rendering as a visible glitch.

## What Changed
- CONTRIBUTING.md: removed an extraneous "the" from the WCAG accessibility testing bullet
- README.md: joined an orphan period back onto the end of the preceding sentence in the User Authentication section

## Why
Test commit to prove out the end-to-end development process. Both issues are visible to anyone reading the rendered Markdown on GitHub. Trivial polish, no behavioural impact, no code touched.