### PR TITLE
fix(AHWR-1761): exclude NOT_AGREED applications from select funding #patch

### DIFF
--- a/app/lib/application-helper.js
+++ b/app/lib/application-helper.js
@@ -1,0 +1,41 @@
+import {
+  APPLICATION_REFERENCE_PREFIX_NEW_WORLD,
+  APPLICATION_REFERENCE_PREFIX_OLD_WORLD,
+  APPLICATION_REFERENCE_PREFIX_POULTRY,
+} from "ffc-ahwr-common-library";
+
+import { getApplicationsBySbi } from "../api-requests/application-api.js";
+import { areDatesWithin10Months } from "./utils.js";
+
+const nonClaimableApplicationStatuses = new Set(["NOT_AGREED"]);
+
+const isClaimableApplication = (application) =>
+  !nonClaimableApplicationStatuses.has(application.status);
+
+export const getLatestApplications = async (sbi, logger) => {
+  const applications = await getApplicationsBySbi(sbi, logger);
+
+  const latestEndemicsApplication = applications.find(
+    (application) =>
+      application.reference.startsWith(APPLICATION_REFERENCE_PREFIX_NEW_WORLD) &&
+      isClaimableApplication(application),
+  );
+
+  const latestPoultryApplication = applications.find(
+    (application) =>
+      application.reference.startsWith(APPLICATION_REFERENCE_PREFIX_POULTRY) &&
+      isClaimableApplication(application),
+  );
+
+  // get latest old world - if there isn't one, or it's not within 10 months of the new world one, then we won't consider it,
+  // and thus return undefined
+  const latestVetVisitApplication = applications.find((application) => {
+    // endemics application must have been created within 10 months of vet-visit application visit date
+    return (
+      application.reference.startsWith(APPLICATION_REFERENCE_PREFIX_OLD_WORLD) &&
+      areDatesWithin10Months(application.data?.visitDate, latestEndemicsApplication?.createdAt ?? 0)
+    );
+  });
+
+  return { latestEndemicsApplication, latestPoultryApplication, latestVetVisitApplication };
+};

--- a/app/lib/application-helper.test.js
+++ b/app/lib/application-helper.test.js
@@ -1,0 +1,271 @@
+import { getLatestApplications } from "./application-helper.js";
+import { getApplicationsBySbi } from "../api-requests/application-api.js";
+
+jest.mock("../api-requests/application-api.js");
+
+describe("getLatestApplications", () => {
+  const mockLogger = {};
+
+  it("returns new world application and relevant old world application", async () => {
+    const newWorld = {
+      type: "EE",
+      reference: "IAHW-1111-2222",
+      createdAt: "2025-05-01T00:00:00.000Z",
+    };
+    const oldWorld = {
+      type: "VV",
+      reference: "AHWR-1111-2222",
+      data: {
+        visitDate: "2025-04-15T00:00:00.000Z",
+      },
+    };
+    getApplicationsBySbi.mockResolvedValueOnce([newWorld, oldWorld]);
+
+    const { latestEndemicsApplication, latestVetVisitApplication } = await getLatestApplications(
+      "123456789",
+      mockLogger,
+    );
+
+    expect(latestEndemicsApplication.reference).toBe("IAHW-1111-2222");
+    expect(latestVetVisitApplication.reference).toBe("AHWR-1111-2222");
+  });
+
+  it("returns new world application and ignores not relevant old world application", async () => {
+    const newWorld = {
+      type: "EE",
+      reference: "IAHW-1111-2222",
+      createdAt: "2025-05-01T00:00:00.000Z",
+    };
+    const oldWorld = {
+      type: "VV",
+      reference: "AHWR-1111-2222",
+      data: {
+        visitDate: "2023-04-15T00:00:00.000Z",
+      },
+    };
+    getApplicationsBySbi.mockResolvedValueOnce([newWorld, oldWorld]);
+
+    const { latestEndemicsApplication, latestVetVisitApplication } = await getLatestApplications(
+      "123456789",
+      mockLogger,
+    );
+
+    expect(latestEndemicsApplication.reference).toBe("IAHW-1111-2222");
+    expect(latestVetVisitApplication).toBeUndefined();
+  });
+
+  it("returns new world application when no old world application", async () => {
+    const newWorld = {
+      type: "EE",
+      reference: "IAHW-1111-2222",
+      createdAt: "2025-05-01T00:00:00.000Z",
+    };
+    getApplicationsBySbi.mockResolvedValueOnce([newWorld]);
+
+    const { latestEndemicsApplication, latestVetVisitApplication } = await getLatestApplications(
+      "123456789",
+      mockLogger,
+    );
+
+    expect(latestEndemicsApplication.reference).toBe("IAHW-1111-2222");
+    expect(latestVetVisitApplication).toBeUndefined();
+  });
+
+  it("returns nothing when old world application only", async () => {
+    const oldWorld = {
+      type: "VV",
+      reference: "AHWR-1111-2222",
+      data: {
+        visitDate: "2023-04-15T00:00:00.000Z",
+      },
+    };
+    getApplicationsBySbi.mockResolvedValueOnce([oldWorld]);
+
+    const { latestEndemicsApplication, latestVetVisitApplication } = await getLatestApplications(
+      "123456789",
+      mockLogger,
+    );
+
+    expect(latestEndemicsApplication).toBeUndefined();
+    expect(latestVetVisitApplication).toBeUndefined();
+  });
+
+  it("returns poultry application", async () => {
+    const poultry = {
+      type: "POUL",
+      reference: "POUL-1111-2222",
+      createdAt: "2025-05-01T00:00:00.000Z",
+    };
+    const newWorld = {
+      type: "EE",
+      reference: "IAHW-1111-2222",
+      createdAt: "2025-05-01T00:00:00.000Z",
+    };
+    const oldWorld = {
+      type: "VV",
+      reference: "AHWR-1111-2222",
+      data: {
+        visitDate: "2023-04-15T00:00:00.000Z",
+      },
+    };
+    getApplicationsBySbi.mockResolvedValueOnce([newWorld, oldWorld, poultry]);
+
+    const { latestPoultryApplication, latestEndemicsApplication, latestVetVisitApplication } =
+      await getLatestApplications("123456789", mockLogger);
+
+    expect(latestEndemicsApplication.reference).toBe("IAHW-1111-2222");
+    expect(latestPoultryApplication.reference).toBe("POUL-1111-2222");
+    expect(latestVetVisitApplication).toBeUndefined();
+  });
+
+  it("excludes NOT_AGREED poultry applications when selecting latestPoultryApplication", async () => {
+    const rejectedPoultry = {
+      type: "POUL",
+      reference: "POUL-1111-2222",
+      createdAt: "2026-04-29T00:00:00.000Z",
+      status: "NOT_AGREED",
+    };
+    getApplicationsBySbi.mockResolvedValueOnce([rejectedPoultry]);
+
+    const { latestPoultryApplication } = await getLatestApplications("123456789", mockLogger);
+
+    expect(latestPoultryApplication).toBeUndefined();
+  });
+
+  it("prefers an AGREED poultry application over a more recent NOT_AGREED poultry application", async () => {
+    const rejectedPoultry = {
+      type: "POUL",
+      reference: "POUL-9999-9999",
+      createdAt: "2026-04-29T00:00:00.000Z",
+      status: "NOT_AGREED",
+    };
+    const agreedPoultry = {
+      type: "POUL",
+      reference: "POUL-1111-2222",
+      createdAt: "2026-01-15T00:00:00.000Z",
+      status: "AGREED",
+    };
+    // rejected first to mimic typical date-desc ordering returned by the backend
+    getApplicationsBySbi.mockResolvedValueOnce([rejectedPoultry, agreedPoultry]);
+
+    const { latestPoultryApplication } = await getLatestApplications("123456789", mockLogger);
+
+    expect(latestPoultryApplication.reference).toBe("POUL-1111-2222");
+  });
+
+  it("excludes NOT_AGREED endemics applications when selecting latestEndemicsApplication", async () => {
+    const rejectedEndemics = {
+      type: "EE",
+      reference: "IAHW-1111-2222",
+      createdAt: "2026-04-29T00:00:00.000Z",
+      status: "NOT_AGREED",
+    };
+    getApplicationsBySbi.mockResolvedValueOnce([rejectedEndemics]);
+
+    const { latestEndemicsApplication } = await getLatestApplications("123456789", mockLogger);
+
+    expect(latestEndemicsApplication).toBeUndefined();
+  });
+
+  it("prefers an AGREED endemics application over a more recent NOT_AGREED endemics application", async () => {
+    const rejectedEndemics = {
+      type: "EE",
+      reference: "IAHW-9999-9999",
+      createdAt: "2026-04-29T00:00:00.000Z",
+      status: "NOT_AGREED",
+    };
+    const agreedEndemics = {
+      type: "EE",
+      reference: "IAHW-1111-2222",
+      createdAt: "2026-01-15T00:00:00.000Z",
+      status: "AGREED",
+    };
+    getApplicationsBySbi.mockResolvedValueOnce([rejectedEndemics, agreedEndemics]);
+
+    const { latestEndemicsApplication } = await getLatestApplications("123456789", mockLogger);
+
+    expect(latestEndemicsApplication.reference).toBe("IAHW-1111-2222");
+  });
+
+  it("filters poultry and endemics independently", async () => {
+    const rejectedPoultry = {
+      type: "POUL",
+      reference: "POUL-9999-9999",
+      createdAt: "2026-04-29T00:00:00.000Z",
+      status: "NOT_AGREED",
+    };
+    const agreedEndemics = {
+      type: "EE",
+      reference: "IAHW-1111-2222",
+      createdAt: "2026-01-15T00:00:00.000Z",
+      status: "AGREED",
+    };
+    getApplicationsBySbi.mockResolvedValueOnce([rejectedPoultry, agreedEndemics]);
+
+    const { latestPoultryApplication, latestEndemicsApplication } = await getLatestApplications(
+      "123456789",
+      mockLogger,
+    );
+
+    expect(latestPoultryApplication).toBeUndefined();
+    expect(latestEndemicsApplication.reference).toBe("IAHW-1111-2222");
+  });
+
+  it("returns AGREED applications unchanged when no NOT_AGREED is present", async () => {
+    const agreedEndemics = {
+      type: "EE",
+      reference: "IAHW-1111-2222",
+      createdAt: "2026-01-15T00:00:00.000Z",
+      status: "AGREED",
+    };
+    const agreedPoultry = {
+      type: "POUL",
+      reference: "POUL-1111-2222",
+      createdAt: "2026-01-15T00:00:00.000Z",
+      status: "AGREED",
+    };
+    getApplicationsBySbi.mockResolvedValueOnce([agreedEndemics, agreedPoultry]);
+
+    const { latestEndemicsApplication, latestPoultryApplication } = await getLatestApplications(
+      "123456789",
+      mockLogger,
+    );
+
+    expect(latestEndemicsApplication).toBe(agreedEndemics);
+    expect(latestPoultryApplication).toBe(agreedPoultry);
+  });
+
+  it("resolves latestVetVisitApplication against the AGREED endemics application's createdAt, ignoring a more recent NOT_AGREED one", async () => {
+    const oldWorldVisitDate = "2025-04-15T00:00:00.000Z";
+    const dateWithinTenMonthsOfOldWorldVisit = "2025-09-01T00:00:00.000Z";
+    const dateBeyondTenMonthsOfOldWorldVisit = "2026-05-01T00:00:00.000Z";
+    const rejectedEndemics = {
+      type: "EE",
+      reference: "IAHW-9999-9999",
+      createdAt: dateBeyondTenMonthsOfOldWorldVisit,
+      status: "NOT_AGREED",
+    };
+    const agreedEndemics = {
+      type: "EE",
+      reference: "IAHW-1111-2222",
+      createdAt: dateWithinTenMonthsOfOldWorldVisit,
+      status: "AGREED",
+    };
+    const oldWorld = {
+      type: "VV",
+      reference: "AHWR-1111-2222",
+      data: {
+        visitDate: oldWorldVisitDate,
+      },
+    };
+    getApplicationsBySbi.mockResolvedValueOnce([rejectedEndemics, agreedEndemics, oldWorld]);
+
+    const { latestEndemicsApplication, latestVetVisitApplication } = await getLatestApplications(
+      "123456789",
+      mockLogger,
+    );
+
+    expect(latestEndemicsApplication.reference).toBe("IAHW-1111-2222");
+    expect(latestVetVisitApplication.reference).toBe("AHWR-1111-2222");
+  });
+});

--- a/app/lib/context-helper.js
+++ b/app/lib/context-helper.js
@@ -36,12 +36,19 @@ import {
 
 const { customerSurvey } = config;
 
+const nonClaimableApplicationStatuses = new Set(["NOT_AGREED"]);
+
+const isClaimableApplication = (application) =>
+  !nonClaimableApplicationStatuses.has(application.status);
+
 export async function refreshApplications(sbi, request) {
   const applications = await getApplicationsBySbi(sbi, request.logger);
 
   // get latest new world
-  const latestEndemicsApplication = applications.find((application) =>
-    application.reference.startsWith(APPLICATION_REFERENCE_PREFIX_NEW_WORLD),
+  const latestEndemicsApplication = applications.find(
+    (application) =>
+      application.reference.startsWith(APPLICATION_REFERENCE_PREFIX_NEW_WORLD) &&
+      isClaimableApplication(application),
   );
 
   // get latest old world - if there isn't one, or it's not within 10 months of the new world one, then we won't consider it,
@@ -68,8 +75,10 @@ export async function refreshApplications(sbi, request) {
     latestEndemicsApplication,
   );
 
-  const latestPoultryApplication = applications.find((application) =>
-    application.reference.startsWith(APPLICATION_REFERENCE_PREFIX_POULTRY),
+  const latestPoultryApplication = applications.find(
+    (application) =>
+      application.reference.startsWith(APPLICATION_REFERENCE_PREFIX_POULTRY) &&
+      isClaimableApplication(application),
   );
 
   await setSessionData(

--- a/app/lib/context-helper.js
+++ b/app/lib/context-helper.js
@@ -7,10 +7,9 @@ import {
   clearEndemicsClaim,
   clearPoultryClaim,
 } from "../session/index.js";
-import { areDatesWithin10Months } from "./utils.js";
-import { getApplicationsBySbi } from "../api-requests/application-api.js";
 import { getClaimsByApplicationReference } from "../api-requests/claim-api.js";
 import { createTempReference } from "./create-temp-ref.js";
+import { getLatestApplications } from "./application-helper.js";
 import {
   MULTIPLE_HERDS_RELEASE_DATE,
   ONLY_HERD,
@@ -25,41 +24,13 @@ import {
   poultryApplyUrls,
   poultryClaimUrls,
 } from "../constants/routes.js";
-import {
-  AHWR_SCHEME,
-  APPLICATION_REFERENCE_PREFIX_NEW_WORLD,
-  APPLICATION_REFERENCE_PREFIX_OLD_WORLD,
-  APPLICATION_REFERENCE_PREFIX_POULTRY,
-  claimType,
-  POULTRY_SCHEME,
-} from "ffc-ahwr-common-library";
+import { AHWR_SCHEME, claimType, POULTRY_SCHEME } from "ffc-ahwr-common-library";
 
 const { customerSurvey } = config;
 
-const nonClaimableApplicationStatuses = new Set(["NOT_AGREED"]);
-
-const isClaimableApplication = (application) =>
-  !nonClaimableApplicationStatuses.has(application.status);
-
 export async function refreshApplications(sbi, request) {
-  const applications = await getApplicationsBySbi(sbi, request.logger);
-
-  // get latest new world
-  const latestEndemicsApplication = applications.find(
-    (application) =>
-      application.reference.startsWith(APPLICATION_REFERENCE_PREFIX_NEW_WORLD) &&
-      isClaimableApplication(application),
-  );
-
-  // get latest old world - if there isn't one, or it's not within 10 months of the new world one, then we won't consider it,
-  // and thus return undefined
-  const latestVetVisitApplication = applications.find((application) => {
-    // endemics application must have been created within 10 months of vet-visit application visit date
-    return (
-      application.reference.startsWith(APPLICATION_REFERENCE_PREFIX_OLD_WORLD) &&
-      areDatesWithin10Months(application.data?.visitDate, latestEndemicsApplication?.createdAt ?? 0)
-    );
-  });
+  const { latestEndemicsApplication, latestPoultryApplication, latestVetVisitApplication } =
+    await getLatestApplications(sbi, request.logger);
 
   await setSessionData(
     request,
@@ -73,12 +44,6 @@ export async function refreshApplications(sbi, request) {
     sessionEntryKeys.endemicsClaim,
     sessionKeys.endemicsClaim.latestEndemicsApplication,
     latestEndemicsApplication,
-  );
-
-  const latestPoultryApplication = applications.find(
-    (application) =>
-      application.reference.startsWith(APPLICATION_REFERENCE_PREFIX_POULTRY) &&
-      isClaimableApplication(application),
   );
 
   await setSessionData(

--- a/app/lib/context-helper.test.js
+++ b/app/lib/context-helper.test.js
@@ -361,6 +361,181 @@ describe("context-helper", () => {
         undefined,
       );
     });
+
+    it("excludes NOT_AGREED poultry applications when selecting latestPoultryApplication", async () => {
+      const rejectedPoultry = {
+        type: "POUL",
+        reference: "POUL-1111-2222",
+        createdAt: "2026-04-29T00:00:00.000Z",
+        status: "NOT_AGREED",
+      };
+      getApplicationsBySbi.mockResolvedValueOnce([rejectedPoultry]);
+
+      const { latestPoultryApplication } = await refreshApplications("123456789", mockRequest);
+
+      expect(latestPoultryApplication).toBeUndefined();
+      expect(setSessionData).toHaveBeenCalledWith(
+        mockRequest,
+        "poultryClaim",
+        "latestPoultryApplication",
+        undefined,
+      );
+    });
+
+    it("prefers an AGREED poultry application over a more recent NOT_AGREED poultry application", async () => {
+      const rejectedPoultry = {
+        type: "POUL",
+        reference: "POUL-9999-9999",
+        createdAt: "2026-04-29T00:00:00.000Z",
+        status: "NOT_AGREED",
+      };
+      const agreedPoultry = {
+        type: "POUL",
+        reference: "POUL-1111-2222",
+        createdAt: "2026-01-15T00:00:00.000Z",
+        status: "AGREED",
+      };
+      // rejected first to mimic typical date-desc ordering returned by the backend
+      getApplicationsBySbi.mockResolvedValueOnce([rejectedPoultry, agreedPoultry]);
+
+      const { latestPoultryApplication } = await refreshApplications("123456789", mockRequest);
+
+      expect(latestPoultryApplication.reference).toBe("POUL-1111-2222");
+      expect(setSessionData).toHaveBeenCalledWith(
+        mockRequest,
+        "poultryClaim",
+        "latestPoultryApplication",
+        agreedPoultry,
+      );
+    });
+
+    it("excludes NOT_AGREED endemics applications when selecting latestEndemicsApplication", async () => {
+      const rejectedEndemics = {
+        type: "EE",
+        reference: "IAHW-1111-2222",
+        createdAt: "2026-04-29T00:00:00.000Z",
+        status: "NOT_AGREED",
+      };
+      getApplicationsBySbi.mockResolvedValueOnce([rejectedEndemics]);
+
+      const { latestEndemicsApplication } = await refreshApplications("123456789", mockRequest);
+
+      expect(latestEndemicsApplication).toBeUndefined();
+      expect(setSessionData).toHaveBeenCalledWith(
+        mockRequest,
+        "endemicsClaim",
+        "latestEndemicsApplication",
+        undefined,
+      );
+    });
+
+    it("prefers an AGREED endemics application over a more recent NOT_AGREED endemics application", async () => {
+      const rejectedEndemics = {
+        type: "EE",
+        reference: "IAHW-9999-9999",
+        createdAt: "2026-04-29T00:00:00.000Z",
+        status: "NOT_AGREED",
+      };
+      const agreedEndemics = {
+        type: "EE",
+        reference: "IAHW-1111-2222",
+        createdAt: "2026-01-15T00:00:00.000Z",
+        status: "AGREED",
+      };
+      getApplicationsBySbi.mockResolvedValueOnce([rejectedEndemics, agreedEndemics]);
+
+      const { latestEndemicsApplication } = await refreshApplications("123456789", mockRequest);
+
+      expect(latestEndemicsApplication.reference).toBe("IAHW-1111-2222");
+      expect(setSessionData).toHaveBeenCalledWith(
+        mockRequest,
+        "endemicsClaim",
+        "latestEndemicsApplication",
+        agreedEndemics,
+      );
+    });
+
+    it("filters poultry and endemics independently", async () => {
+      const rejectedPoultry = {
+        type: "POUL",
+        reference: "POUL-9999-9999",
+        createdAt: "2026-04-29T00:00:00.000Z",
+        status: "NOT_AGREED",
+      };
+      const agreedEndemics = {
+        type: "EE",
+        reference: "IAHW-1111-2222",
+        createdAt: "2026-01-15T00:00:00.000Z",
+        status: "AGREED",
+      };
+      getApplicationsBySbi.mockResolvedValueOnce([rejectedPoultry, agreedEndemics]);
+
+      const { latestPoultryApplication, latestEndemicsApplication } = await refreshApplications(
+        "123456789",
+        mockRequest,
+      );
+
+      expect(latestPoultryApplication).toBeUndefined();
+      expect(latestEndemicsApplication.reference).toBe("IAHW-1111-2222");
+    });
+
+    it("returns AGREED applications unchanged when no NOT_AGREED is present", async () => {
+      const agreedEndemics = {
+        type: "EE",
+        reference: "IAHW-1111-2222",
+        createdAt: "2026-01-15T00:00:00.000Z",
+        status: "AGREED",
+      };
+      const agreedPoultry = {
+        type: "POUL",
+        reference: "POUL-1111-2222",
+        createdAt: "2026-01-15T00:00:00.000Z",
+        status: "AGREED",
+      };
+      getApplicationsBySbi.mockResolvedValueOnce([agreedEndemics, agreedPoultry]);
+
+      const { latestEndemicsApplication, latestPoultryApplication } = await refreshApplications(
+        "123456789",
+        mockRequest,
+      );
+
+      expect(latestEndemicsApplication).toBe(agreedEndemics);
+      expect(latestPoultryApplication).toBe(agreedPoultry);
+    });
+
+    it("resolves latestVetVisitApplication against the AGREED endemics application's createdAt, ignoring a more recent NOT_AGREED one", async () => {
+      const oldWorldVisitDate = "2025-04-15T00:00:00.000Z";
+      const dateWithinTenMonthsOfOldWorldVisit = "2025-09-01T00:00:00.000Z";
+      const dateBeyondTenMonthsOfOldWorldVisit = "2026-05-01T00:00:00.000Z";
+      const rejectedEndemics = {
+        type: "EE",
+        reference: "IAHW-9999-9999",
+        createdAt: dateBeyondTenMonthsOfOldWorldVisit,
+        status: "NOT_AGREED",
+      };
+      const agreedEndemics = {
+        type: "EE",
+        reference: "IAHW-1111-2222",
+        createdAt: dateWithinTenMonthsOfOldWorldVisit,
+        status: "AGREED",
+      };
+      const oldWorld = {
+        type: "VV",
+        reference: "AHWR-1111-2222",
+        data: {
+          visitDate: oldWorldVisitDate,
+        },
+      };
+      getApplicationsBySbi.mockResolvedValueOnce([rejectedEndemics, agreedEndemics, oldWorld]);
+
+      const { latestEndemicsApplication, latestVetVisitApplication } = await refreshApplications(
+        "123456789",
+        mockRequest,
+      );
+
+      expect(latestEndemicsApplication.reference).toBe("IAHW-1111-2222");
+      expect(latestVetVisitApplication.reference).toBe("AHWR-1111-2222");
+    });
   });
 
   describe("getScheme", () => {

--- a/app/lib/context-helper.test.js
+++ b/app/lib/context-helper.test.js
@@ -16,7 +16,6 @@ import {
   ONLY_HERD,
   PI_HUNT_AND_DAIRY_FOLLOW_UP_RELEASE_DATE,
 } from "../constants/claim-constants.js";
-import { getApplicationsBySbi } from "../api-requests/application-api.js";
 import { getClaimsByApplicationReference } from "../api-requests/claim-api.js";
 import {
   clearEndemicsClaim,
@@ -27,6 +26,7 @@ import {
   setSessionData,
 } from "../session/index.js";
 import { createTempReference } from "./create-temp-ref.js";
+import { getLatestApplications } from "./application-helper.js";
 import { AHWR_SCHEME, POULTRY_SCHEME } from "ffc-ahwr-common-library";
 import { config } from "../config/index.js";
 import {
@@ -36,7 +36,7 @@ import {
   poultryClaimRoutes,
 } from "../constants/routes.js";
 
-jest.mock("../api-requests/application-api.js");
+jest.mock("./application-helper.js");
 jest.mock("../api-requests/claim-api.js");
 jest.mock("../session/index.js");
 jest.mock("./create-temp-ref.js");
@@ -188,353 +188,88 @@ describe("context-helper", () => {
   });
 
   describe("refreshApplications", () => {
-    const mockRequest = {};
-    it("returns new world application and relevant old world application", async () => {
-      const newWorld = {
-        type: "EE",
-        reference: "IAHW-1111-2222",
-        createdAt: "2025-05-01T00:00:00.000Z",
-      };
-      const oldWorld = {
-        type: "VV",
-        reference: "AHWR-1111-2222",
-        data: {
-          visitDate: "2025-04-15T00:00:00.000Z",
-        },
-      };
-      getApplicationsBySbi.mockResolvedValueOnce([newWorld, oldWorld]);
-      const { latestEndemicsApplication, latestVetVisitApplication } = await refreshApplications(
-        "123456789",
-        mockRequest,
-      );
+    const mockRequest = { logger: {} };
 
-      expect(latestEndemicsApplication.reference).toBe("IAHW-1111-2222");
-      expect(latestVetVisitApplication.reference).toBe("AHWR-1111-2222");
-      expect(setSessionData).toHaveBeenCalledWith(
-        mockRequest,
-        "endemicsClaim",
-        "latestEndemicsApplication",
-        newWorld,
-      );
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it("calls getLatestApplications with the supplied sbi and request logger", async () => {
+      getLatestApplications.mockResolvedValueOnce({
+        latestEndemicsApplication: undefined,
+        latestPoultryApplication: undefined,
+        latestVetVisitApplication: undefined,
+      });
+
+      await refreshApplications("123456789", mockRequest);
+
+      expect(getLatestApplications).toHaveBeenCalledWith("123456789", mockRequest.logger);
+    });
+
+    it("writes the resolved applications to session and returns them", async () => {
+      const latestEndemicsApplication = { reference: "IAHW-1111-2222" };
+      const latestPoultryApplication = { reference: "POUL-3333-4444" };
+      const latestVetVisitApplication = { reference: "AHWR-5555-6666" };
+      getLatestApplications.mockResolvedValueOnce({
+        latestEndemicsApplication,
+        latestPoultryApplication,
+        latestVetVisitApplication,
+      });
+
+      const result = await refreshApplications("123456789", mockRequest);
+
       expect(setSessionData).toHaveBeenCalledWith(
         mockRequest,
         "endemicsClaim",
         "latestVetVisitApplication",
-        oldWorld,
+        latestVetVisitApplication,
       );
-    });
-
-    it("returns new world application and ignores not relevant old world application", async () => {
-      const newWorld = {
-        type: "EE",
-        reference: "IAHW-1111-2222",
-        createdAt: "2025-05-01T00:00:00.000Z",
-      };
-      const oldWorld = {
-        type: "VV",
-        reference: "AHWR-1111-2222",
-        data: {
-          visitDate: "2023-04-15T00:00:00.000Z",
-        },
-      };
-      getApplicationsBySbi.mockResolvedValueOnce([newWorld, oldWorld]);
-      const { latestEndemicsApplication, latestVetVisitApplication } = await refreshApplications(
-        "123456789",
-        mockRequest,
-      );
-
-      expect(latestEndemicsApplication.reference).toBe("IAHW-1111-2222");
-      expect(latestVetVisitApplication).toBeUndefined();
       expect(setSessionData).toHaveBeenCalledWith(
         mockRequest,
         "endemicsClaim",
         "latestEndemicsApplication",
-        newWorld,
-      );
-      expect(setSessionData).toHaveBeenCalledWith(
-        mockRequest,
-        "endemicsClaim",
-        "latestVetVisitApplication",
-        undefined,
-      );
-    });
-
-    it("returns new world application when no old world application", async () => {
-      const newWorld = {
-        type: "EE",
-        reference: "IAHW-1111-2222",
-        createdAt: "2025-05-01T00:00:00.000Z",
-      };
-      getApplicationsBySbi.mockResolvedValueOnce([newWorld]);
-      const { latestEndemicsApplication, latestVetVisitApplication } = await refreshApplications(
-        "123456789",
-        mockRequest,
-      );
-
-      expect(latestEndemicsApplication.reference).toBe("IAHW-1111-2222");
-      expect(latestVetVisitApplication).toBeUndefined();
-      expect(setSessionData).toHaveBeenCalledWith(
-        mockRequest,
-        "endemicsClaim",
-        "latestEndemicsApplication",
-        newWorld,
-      );
-      expect(setSessionData).toHaveBeenCalledWith(
-        mockRequest,
-        "endemicsClaim",
-        "latestVetVisitApplication",
-        undefined,
-      );
-    });
-
-    it("returns nothing when old world application only", async () => {
-      const oldWorld = {
-        type: "VV",
-        reference: "AHWR-1111-2222",
-        data: {
-          visitDate: "2023-04-15T00:00:00.000Z",
-        },
-      };
-      getApplicationsBySbi.mockResolvedValueOnce([oldWorld]);
-      const { latestEndemicsApplication, latestVetVisitApplication } = await refreshApplications(
-        "123456789",
-        mockRequest,
-      );
-
-      expect(latestVetVisitApplication).toBeUndefined();
-      expect(latestEndemicsApplication).toBeUndefined();
-      expect(setSessionData).toHaveBeenCalledWith(
-        mockRequest,
-        "endemicsClaim",
-        "latestEndemicsApplication",
-        undefined,
-      );
-      expect(setSessionData).toHaveBeenCalledWith(
-        mockRequest,
-        "endemicsClaim",
-        "latestVetVisitApplication",
-        undefined,
-      );
-    });
-
-    it("returns poultry application", async () => {
-      const poultry = {
-        type: "POUL",
-        reference: "POUL-1111-2222",
-        createdAt: "2025-05-01T00:00:00.000Z",
-      };
-      const newWorld = {
-        type: "EE",
-        reference: "IAHW-1111-2222",
-        createdAt: "2025-05-01T00:00:00.000Z",
-      };
-      const oldWorld = {
-        type: "VV",
-        reference: "AHWR-1111-2222",
-        data: {
-          visitDate: "2023-04-15T00:00:00.000Z",
-        },
-      };
-      getApplicationsBySbi.mockResolvedValueOnce([newWorld, oldWorld, poultry]);
-      const { latestPoultryApplication, latestEndemicsApplication, latestVetVisitApplication } =
-        await refreshApplications("123456789", mockRequest);
-
-      expect(latestEndemicsApplication.reference).toBe("IAHW-1111-2222");
-      expect(latestPoultryApplication.reference).toBe("POUL-1111-2222");
-      expect(latestVetVisitApplication).toBeUndefined();
-      expect(setSessionData).toHaveBeenCalledWith(
-        mockRequest,
-        "endemicsClaim",
-        "latestEndemicsApplication",
-        newWorld,
+        latestEndemicsApplication,
       );
       expect(setSessionData).toHaveBeenCalledWith(
         mockRequest,
         "poultryClaim",
         "latestPoultryApplication",
-        poultry,
+        latestPoultryApplication,
       );
+      expect(result).toEqual({
+        latestEndemicsApplication,
+        latestPoultryApplication,
+        latestVetVisitApplication,
+      });
+    });
+
+    it("writes undefined to session when no applications were resolved", async () => {
+      getLatestApplications.mockResolvedValueOnce({
+        latestEndemicsApplication: undefined,
+        latestPoultryApplication: undefined,
+        latestVetVisitApplication: undefined,
+      });
+
+      await refreshApplications("123456789", mockRequest);
+
       expect(setSessionData).toHaveBeenCalledWith(
         mockRequest,
         "endemicsClaim",
         "latestVetVisitApplication",
         undefined,
       );
-    });
-
-    it("excludes NOT_AGREED poultry applications when selecting latestPoultryApplication", async () => {
-      const rejectedPoultry = {
-        type: "POUL",
-        reference: "POUL-1111-2222",
-        createdAt: "2026-04-29T00:00:00.000Z",
-        status: "NOT_AGREED",
-      };
-      getApplicationsBySbi.mockResolvedValueOnce([rejectedPoultry]);
-
-      const { latestPoultryApplication } = await refreshApplications("123456789", mockRequest);
-
-      expect(latestPoultryApplication).toBeUndefined();
+      expect(setSessionData).toHaveBeenCalledWith(
+        mockRequest,
+        "endemicsClaim",
+        "latestEndemicsApplication",
+        undefined,
+      );
       expect(setSessionData).toHaveBeenCalledWith(
         mockRequest,
         "poultryClaim",
         "latestPoultryApplication",
         undefined,
       );
-    });
-
-    it("prefers an AGREED poultry application over a more recent NOT_AGREED poultry application", async () => {
-      const rejectedPoultry = {
-        type: "POUL",
-        reference: "POUL-9999-9999",
-        createdAt: "2026-04-29T00:00:00.000Z",
-        status: "NOT_AGREED",
-      };
-      const agreedPoultry = {
-        type: "POUL",
-        reference: "POUL-1111-2222",
-        createdAt: "2026-01-15T00:00:00.000Z",
-        status: "AGREED",
-      };
-      // rejected first to mimic typical date-desc ordering returned by the backend
-      getApplicationsBySbi.mockResolvedValueOnce([rejectedPoultry, agreedPoultry]);
-
-      const { latestPoultryApplication } = await refreshApplications("123456789", mockRequest);
-
-      expect(latestPoultryApplication.reference).toBe("POUL-1111-2222");
-      expect(setSessionData).toHaveBeenCalledWith(
-        mockRequest,
-        "poultryClaim",
-        "latestPoultryApplication",
-        agreedPoultry,
-      );
-    });
-
-    it("excludes NOT_AGREED endemics applications when selecting latestEndemicsApplication", async () => {
-      const rejectedEndemics = {
-        type: "EE",
-        reference: "IAHW-1111-2222",
-        createdAt: "2026-04-29T00:00:00.000Z",
-        status: "NOT_AGREED",
-      };
-      getApplicationsBySbi.mockResolvedValueOnce([rejectedEndemics]);
-
-      const { latestEndemicsApplication } = await refreshApplications("123456789", mockRequest);
-
-      expect(latestEndemicsApplication).toBeUndefined();
-      expect(setSessionData).toHaveBeenCalledWith(
-        mockRequest,
-        "endemicsClaim",
-        "latestEndemicsApplication",
-        undefined,
-      );
-    });
-
-    it("prefers an AGREED endemics application over a more recent NOT_AGREED endemics application", async () => {
-      const rejectedEndemics = {
-        type: "EE",
-        reference: "IAHW-9999-9999",
-        createdAt: "2026-04-29T00:00:00.000Z",
-        status: "NOT_AGREED",
-      };
-      const agreedEndemics = {
-        type: "EE",
-        reference: "IAHW-1111-2222",
-        createdAt: "2026-01-15T00:00:00.000Z",
-        status: "AGREED",
-      };
-      getApplicationsBySbi.mockResolvedValueOnce([rejectedEndemics, agreedEndemics]);
-
-      const { latestEndemicsApplication } = await refreshApplications("123456789", mockRequest);
-
-      expect(latestEndemicsApplication.reference).toBe("IAHW-1111-2222");
-      expect(setSessionData).toHaveBeenCalledWith(
-        mockRequest,
-        "endemicsClaim",
-        "latestEndemicsApplication",
-        agreedEndemics,
-      );
-    });
-
-    it("filters poultry and endemics independently", async () => {
-      const rejectedPoultry = {
-        type: "POUL",
-        reference: "POUL-9999-9999",
-        createdAt: "2026-04-29T00:00:00.000Z",
-        status: "NOT_AGREED",
-      };
-      const agreedEndemics = {
-        type: "EE",
-        reference: "IAHW-1111-2222",
-        createdAt: "2026-01-15T00:00:00.000Z",
-        status: "AGREED",
-      };
-      getApplicationsBySbi.mockResolvedValueOnce([rejectedPoultry, agreedEndemics]);
-
-      const { latestPoultryApplication, latestEndemicsApplication } = await refreshApplications(
-        "123456789",
-        mockRequest,
-      );
-
-      expect(latestPoultryApplication).toBeUndefined();
-      expect(latestEndemicsApplication.reference).toBe("IAHW-1111-2222");
-    });
-
-    it("returns AGREED applications unchanged when no NOT_AGREED is present", async () => {
-      const agreedEndemics = {
-        type: "EE",
-        reference: "IAHW-1111-2222",
-        createdAt: "2026-01-15T00:00:00.000Z",
-        status: "AGREED",
-      };
-      const agreedPoultry = {
-        type: "POUL",
-        reference: "POUL-1111-2222",
-        createdAt: "2026-01-15T00:00:00.000Z",
-        status: "AGREED",
-      };
-      getApplicationsBySbi.mockResolvedValueOnce([agreedEndemics, agreedPoultry]);
-
-      const { latestEndemicsApplication, latestPoultryApplication } = await refreshApplications(
-        "123456789",
-        mockRequest,
-      );
-
-      expect(latestEndemicsApplication).toBe(agreedEndemics);
-      expect(latestPoultryApplication).toBe(agreedPoultry);
-    });
-
-    it("resolves latestVetVisitApplication against the AGREED endemics application's createdAt, ignoring a more recent NOT_AGREED one", async () => {
-      const oldWorldVisitDate = "2025-04-15T00:00:00.000Z";
-      const dateWithinTenMonthsOfOldWorldVisit = "2025-09-01T00:00:00.000Z";
-      const dateBeyondTenMonthsOfOldWorldVisit = "2026-05-01T00:00:00.000Z";
-      const rejectedEndemics = {
-        type: "EE",
-        reference: "IAHW-9999-9999",
-        createdAt: dateBeyondTenMonthsOfOldWorldVisit,
-        status: "NOT_AGREED",
-      };
-      const agreedEndemics = {
-        type: "EE",
-        reference: "IAHW-1111-2222",
-        createdAt: dateWithinTenMonthsOfOldWorldVisit,
-        status: "AGREED",
-      };
-      const oldWorld = {
-        type: "VV",
-        reference: "AHWR-1111-2222",
-        data: {
-          visitDate: oldWorldVisitDate,
-        },
-      };
-      getApplicationsBySbi.mockResolvedValueOnce([rejectedEndemics, agreedEndemics, oldWorld]);
-
-      const { latestEndemicsApplication, latestVetVisitApplication } = await refreshApplications(
-        "123456789",
-        mockRequest,
-      );
-
-      expect(latestEndemicsApplication.reference).toBe("IAHW-1111-2222");
-      expect(latestVetVisitApplication.reference).toBe("AHWR-1111-2222");
     });
   });
 


### PR DESCRIPTION
## Summary
When a farmer reaches the declaration step of an agreement application and then rejects it, the application is persisted in the back-end with status `NOT_AGREED`. On next sign-in, that rejected application was being picked up as the user's most recent application and offered to them on the `Select Funding` screen as a selectable agreement, even though no claim can be raised against it.

This change filters out `NOT_AGREED` applications when establishing the user's most recent endemics and poultry agreements, so rejected applications no longer surface on `Select Funding` or any downstream screen that reads from those session values.

## What Changed
- `NOT_AGREED` applications are excluded when determining the user's latest endemics and latest poultry agreements
- A farmer with only a rejected agreement now sees Select Funding as if they had no agreement of that type, with the prompt to create a new one
- The vet visit application lookup is unaffected by a more recent rejection on the endemics side, since it now anchors on the latest accepted endemics agreement
- Resolution of the user's latest applications has been extracted into a new `application-helper` module, separating the domain logic from the session-population concerns that remain in `context-helper`
- Unit tests for the resolution behaviour now live alongside the new module; the `context-helper` tests have been trimmed to focus on the orchestration role

## Why
The previous behaviour offered users a rejected agreement they could not actually use; selecting it routed them onward where redirect plugins eventually bounced them, with no clear explanation. This change removes the offer at source, so the user is guided to start a fresh agreement instead. The accompanying extraction puts the application-resolution logic in a module named for what it does, making the codebase easier to navigate and the future addition of `WITHDRAWN` (a sibling status raised separately) a one-line change in the right place.