### PR TITLE
feat(AHWR-1808): add back link to cannot continue screen

### DIFF
--- a/app/constants/routes.js
+++ b/app/constants/routes.js
@@ -40,7 +40,6 @@ export const poultryApplyRoutes = {
   timings: "/poultry/timings",
   numbers: "/poultry/numbers",
   declaration: "/poultry/declaration",
-  offerRejected: "/poultry/offer-rejected",
 };
 
 export const applyViews = {
@@ -58,6 +57,7 @@ export const poultryApplyViews = {
   numbers: "poultry/apply/numbers",
   declaration: "poultry/apply/declaration",
   offerRejected: "poultry/apply/offer-rejected",
+  termsRejected: "poultry/apply/terms-rejected",
   confirmation: "poultry/apply/confirmation",
 };
 

--- a/app/routes/poultry/apply/declaration.js
+++ b/app/routes/poultry/apply/declaration.js
@@ -33,9 +33,7 @@ const processRejectedApplication = async (h, request) => {
     tempApplicationId,
   );
 
-  return h.view(poultryApplyViews.offerRejected, {
-    offerRejected: true,
-  });
+  return h.view(poultryApplyViews.offerRejected);
 };
 
 export const poultryDeclarationRouteHandlers = [

--- a/app/routes/poultry/apply/numbers.js
+++ b/app/routes/poultry/apply/numbers.js
@@ -47,8 +47,8 @@ export const poultryNumbersRouteHandlers = [
           "no",
         );
 
-        return h.view(poultryApplyViews.offerRejected, {
-          termsRejected: true,
+        return h.view(poultryApplyViews.termsRejected, {
+          backLink: poultryApplyRoutes.numbers,
         });
       },
     },

--- a/app/routes/poultry/apply/timings.js
+++ b/app/routes/poultry/apply/timings.js
@@ -49,8 +49,8 @@ export const poultryTimingsRouteHandlers = [
           "no",
         );
 
-        return h.view(poultryApplyViews.offerRejected, {
-          termsRejected: true,
+        return h.view(poultryApplyViews.termsRejected, {
+          backLink: poultryApplyRoutes.timings,
         });
       },
     },

--- a/app/routes/poultry/apply/you-can-claim-multiple.js
+++ b/app/routes/poultry/apply/you-can-claim-multiple.js
@@ -79,8 +79,8 @@ export const poultryClaimMultipleRouteHandlers = [
           "no",
         );
 
-        return h.view(poultryApplyViews.offerRejected, {
-          termsRejected: true,
+        return h.view(poultryApplyViews.termsRejected, {
+          backLink: poultryApplyRoutes.youCanClaimMultiple,
         });
       },
     },

--- a/app/views/poultry/apply/offer-rejected.njk
+++ b/app/views/poultry/apply/offer-rejected.njk
@@ -1,29 +1,17 @@
 {% extends './layouts/layout.njk' %}
 
-{% block pageTitle %}
-{% if termsRejected %}
-  You cannot continue with your application - {{ serviceName }} - GOV.UK
-{% elif offerRejected %}
-  Agreement offer rejected - {{ serviceName }} - GOV.UK
-{% endif %}
-{% endblock %}
+{% block pageTitle %}Agreement offer rejected - {{ serviceName }} - GOV.UK{% endblock %}
 
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      {% if termsRejected %}
-        <h1 class="govuk-heading-l">You cannot continue with your application</h1>
-        <p class="govuk-body">Based on your answers you cannot continue with your application.</p>
-        <p class="govuk-body"><a class="govuk-link" rel="external" href="https://www.gov.uk/guidance/funding-for-farmers">Read guidance to find out if you could be eligible for other farming schemes</a>.</p>
-      {% elif offerRejected %}
-        <h1 class="govuk-heading-l">Agreement offer rejected</h1>
-        <p class="govuk-body">You've rejected the agreement offer and your application has been cancelled.</p>
-        <p class="govuk-body">You'll need to start a new application if you:</p>
-        <ul class="govuk-list govuk-list--bullet">
-          <li>rejected the agreement by mistake</li>
-          <li>change your mind and want to apply again</li>
-        </ul>
-      {% endif %}
+      <h1 class="govuk-heading-l">Agreement offer rejected</h1>
+      <p class="govuk-body">You've rejected the agreement offer and your application has been cancelled.</p>
+      <p class="govuk-body">You'll need to start a new application if you:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>rejected the agreement by mistake</li>
+        <li>change your mind and want to apply again</li>
+      </ul>
 
       <p>If you have any questions about your application, contact the Rural Payments Agency.</p>
 

--- a/app/views/poultry/apply/terms-rejected.njk
+++ b/app/views/poultry/apply/terms-rejected.njk
@@ -1,0 +1,25 @@
+{% extends './layouts/layout.njk' %}
+
+{% block pageTitle %}You cannot continue with your application - {{ serviceName }} - GOV.UK{% endblock %}
+
+{% block beforeContent %}
+{{ govukBackLink({
+text: "Back",
+href: backLink,
+attributes: {id: "back"}
+}) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">You cannot continue with your application</h1>
+      <p class="govuk-body">Based on your answers you cannot continue with your application.</p>
+      <p class="govuk-body"><a class="govuk-link" rel="external" href="https://www.gov.uk/guidance/funding-for-farmers">Read guidance to find out if you could be eligible for other farming schemes</a>.</p>
+
+      <p>If you have any questions about your application, contact the Rural Payments Agency.</p>
+
+      {{ rpaContactDetails({email: ruralPaymentsAgency.email, callChargesUri: ruralPaymentsAgency.callChargesUri, telephone: ruralPaymentsAgency.telephone}) }}
+    </div>
+  </div>
+{% endblock %}

--- a/test/integration/narrow/routes/poultry/apply/declaration.test.js
+++ b/test/integration/narrow/routes/poultry/apply/declaration.test.js
@@ -232,6 +232,8 @@ describe("Declaration test", () => {
       expect(callChargesLink.length).toBe(1);
       expect(callChargesLink.text().trim()).toBe("Find out about call charges (opens in new tab)");
 
+      expect($(".govuk-back-link").length).toBe(0);
+
       ok($);
       expect(createApplication).toHaveBeenCalledWith(
         { organisation, ...poultryApplyData, type: "POUL" },

--- a/test/integration/narrow/routes/poultry/apply/numbers.test.js
+++ b/test/integration/narrow/routes/poultry/apply/numbers.test.js
@@ -134,7 +134,7 @@ describe("Check review numbers page test", () => {
       expect(res.headers.location).toEqual(poultryApplyRoutes.timings);
     });
 
-    test("returns 200 to offer rejected page when not agree answer given", async () => {
+    test("returns 200 to terms rejected page with back link when not agree answer given", async () => {
       const res = await server.inject({
         ...options,
         method: "POST",
@@ -145,6 +145,10 @@ describe("Check review numbers page test", () => {
       expect(res.statusCode).toBe(200);
       expect(await axe(res.payload)).toHaveNoViolations();
       expect(res.payload).toContain("You cannot continue with your application");
+
+      const $ = cheerio.load(res.payload);
+      const backLinkHref = $(".govuk-back-link").attr("href");
+      expect(backLinkHref).toContain(poultryApplyRoutes.numbers);
     });
   });
 });

--- a/test/integration/narrow/routes/poultry/apply/timings.test.js
+++ b/test/integration/narrow/routes/poultry/apply/timings.test.js
@@ -123,7 +123,7 @@ describe("Declaration test", () => {
       expect(res.headers.location).toEqual(poultryApplyRoutes.declaration);
     });
 
-    test("returns 200 to agreement rejected page when rejected answer given", async () => {
+    test("returns 200 to terms rejected page with back link when rejected answer given", async () => {
       const res = await server.inject({
         url: poultryApplyRoutes.timings,
         auth,
@@ -131,9 +131,14 @@ describe("Declaration test", () => {
         headers: { cookie: `crumb=${crumb}` },
         payload: { crumb, agreementStatus: "rejected" },
       });
+
       expect(res.statusCode).toBe(200);
       expect(await axe(res.payload)).toHaveNoViolations();
       expect(res.payload).toContain("You cannot continue with your application");
+
+      const $ = cheerio.load(res.payload);
+      const backLinkHref = $(".govuk-back-link").attr("href");
+      expect(backLinkHref).toContain(poultryApplyRoutes.timings);
     });
   });
 });

--- a/test/integration/narrow/routes/poultry/apply/you-can-claim-multiple.test.js
+++ b/test/integration/narrow/routes/poultry/apply/you-can-claim-multiple.test.js
@@ -1,3 +1,4 @@
+import * as cheerio from "cheerio";
 import { getCrumbs } from "../../../../../utils/get-crumbs.js";
 import {
   getSessionData,
@@ -129,7 +130,7 @@ describe("you-can-claim-multiple page", () => {
       expect(res.headers.location).toEqual(poultryApplyRoutes.numbers);
     });
 
-    test("returns 200 and navigates to the offer rejected page when user disagrees", async () => {
+    test("returns 200 and navigates to the terms rejected page with back link when user disagrees", async () => {
       const options = {
         ...postOptionsBase,
         payload: {
@@ -149,6 +150,10 @@ describe("you-can-claim-multiple page", () => {
       );
       expect(await axe(res.payload)).toHaveNoViolations();
       expect(res.payload).toContain("You cannot continue with your application");
+
+      const $ = cheerio.load(res.payload);
+      const backLinkHref = $(".govuk-back-link").attr("href");
+      expect(backLinkHref).toContain(poultryApplyRoutes.youCanClaimMultiple);
     });
   });
 });


### PR DESCRIPTION
## Summary
Adds a Back link to the "You cannot continue with your application" screen in the Poultry Apply journey, so a farmer who answers "I do not agree" on one of the agreement screens can return to that screen and continue.

## What Changed
- New Back link on the Cannot Continue screen, returning to whichever of "What you can claim for", "Minimum number of species" or "Timing rules" the farmer rejected on
- No Back link on the Agreement offer rejected screen reached from the declaration page (it's a separate screen with different content, despite sharing a template until now)
- The shared Nunjucks template behind both screens has been split into two single-purpose files
- Removed a dead route constant that was never referenced anywhere

## Why
Without a Back link, a farmer who picked the wrong answer was effectively forced to abandon the journey. One click back lets them reconsider.

The "Content Updates" copy changes referenced in the ticket title (call-charges link text, agreement-rejected grammar) were already delivered by earlier work, so this PR is back-link only despite the ticket title.

The template split was a prerequisite. The same file was rendering two unrelated screens behind an if/elif switch, with the four POST handlers already dispatching by flag - splitting it makes the screen-to-file mapping match developer expectations and removes a guarded conditional that would have got worse with the Back link.

The Livestock equivalent has the same dual-purpose template and dead route constant pattern, but is out of scope here. Flagged as a future tidy.