### PR TITLE
feat(AHWR-1805): update poultry review your agreement screen content

### DIFF
--- a/app/config/index.js
+++ b/app/config/index.js
@@ -100,6 +100,8 @@ const configSchema = joi.object({
   }),
   poultry: {
     enabled: joi.bool().required(),
+    termsAndConditionsUri: joi.string().required(),
+    vetSummaryTemplateUri: joi.string().required(),
   },
 });
 
@@ -196,6 +198,8 @@ export const getConfig = () => {
     },
     poultry: {
       enabled: process.env.POULTRY_ENABLED === "true",
+      termsAndConditionsUri: process.env.POULTRY_TERMS_AND_CONDITIONS_URL,
+      vetSummaryTemplateUri: process.env.POULTRY_VET_SUMMARY_TEMPLATE_URL,
     },
   };
 

--- a/app/routes/poultry/apply/declaration.js
+++ b/app/routes/poultry/apply/declaration.js
@@ -49,7 +49,8 @@ export const poultryDeclarationRouteHandlers = [
 
         return h.view(poultryApplyViews.declaration, {
           backLink: poultryApplyRoutes.timings,
-          latestTermsAndConditionsUri: `${config.latestTermsAndConditionsUri}?continue=true&backLink=/${poultryApplyRoutes.declaration}`,
+          termsAndConditionsUri: config.poultry.termsAndConditionsUri,
+          vetSummaryTemplateUri: config.poultry.vetSummaryTemplateUri,
           organisation: formatOrganisation(organisation),
         });
       },
@@ -73,7 +74,8 @@ export const poultryDeclarationRouteHandlers = [
           return h
             .view(poultryApplyViews.declaration, {
               backLink: poultryApplyRoutes.timings,
-              latestTermsAndConditionsUri: `${config.latestTermsAndConditionsUri}?continue=true&backLink=/${poultryApplyRoutes.declaration}`,
+              termsAndConditionsUri: config.poultry.termsAndConditionsUri,
+              vetSummaryTemplateUri: config.poultry.vetSummaryTemplateUri,
               errorMessage: {
                 text: "Confirm you have read and agree to the terms and conditions",
               },

--- a/app/views/poultry/apply/declaration.njk
+++ b/app/views/poultry/apply/declaration.njk
@@ -25,40 +25,36 @@
       {% endif %}
       <h1 class="govuk-heading-l">Review your agreement offer</h1>
 
-      <p class="govuk-body">This is an offer of funding to poultry biosecurity review for this business:</p>
+      <p class="govuk-body">This is an offer of Poultry Biosecurity Review funding for this business:</p>
       <div class="govuk-inset-text">
         <span id="organisation-name">{{ organisation.name }}</span><br>
         <span id="organisation-address">{% for line in organisation.address %}{{ line }}{% if not loop.last %}<br>{% endif %}{% endfor %}</span><br>
       SBI: <span id="organisation-sbi">{{ organisation.sbi }}</span>
       </div>
 
-      <h2 class="govuk-heading-s">You may either:</h2>
+      <h2 class="govuk-heading-s">You can either:</h2>
       <ul class="govuk-list govuk-list--bullet">
-        <li>accept this offer of agreement subject to the following</li>
+        <li>accept this offer</li>
         <li>reject this offer</li>
-      </ul><br>
+      </ul>
 
-      <h2 class="govuk-heading-s">You must:</h2>
+      <h2 class="govuk-heading-s">For each review you must:</h2>
       <ul class="govuk-list govuk-list--bullet">
-        <li>allow a vet to asses the biosecurity for the unit being reviewed</li>
+        <li>allow a vet to asses the biosecurity of the site being reviewed</li>
         <li>share details about the vet with the Rural Payments Agency (RPA)</li>
-      </ul><br>
+        <li>ensure the vet completes a <a id="vetSummaryTemplateUri" class="govuk-link" rel="noopener noreferrer" target="_blank" href="{{ vetSummaryTemplateUri }}">poultry biosecurity review vet summary template (opens in new tab)</a> as part of the review</li>
+      </ul>
 
-      <p class="govuk-body">
-        If the RPA requests evidence that your biosecurity review took place, or details of the units you have, you must provide it. This will be on your vet summary.
-      </p>
-
-      <p>If you accept this offer you confirm that:</p>
+      <h2 class="govuk-heading-s">If asked, you must provide the RPA with:</h2>
       <ul class="govuk-list govuk-list--bullet">
-        <li>you have read, understood and agree to follow <a id="termsAndConditionsUri" class="govuk-link" rel="external" href="{{latestTermsAndConditionsUri}}">the agreement terms and conditions</a>
-        </li>
-      </ul><br>
+        <li>evidence that your review took place</li>
+        <li>details of your poultry site</li>
+      </ul>
 
-      <p>The agreement terms and conditions include, but are not limited to:</p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>you must have the minimum number of poultry needed</li>
-        <li>you must follow the rules for timing of biosecurity reviews</li>
-      </ul><br>
+      <p class="govuk-body">This information will be on your vet summary.</p>
+
+      <h2 class="govuk-heading-s">Declaration</h2>
+      <p class="govuk-body">Confirm that you have read <a id="termsAndConditionsUri" class="govuk-link" rel="noopener noreferrer" target="_blank" href="{{ termsAndConditionsUri }}">the agreement terms and conditions (opens in new tab)</a>.</p>
 
       <form method="POST" autocomplete="off" novalidate="novalidate" id ="submitDeclarationForm">
         <input type="hidden" name="crumb" value="{{crumb}}"/>
@@ -75,15 +71,15 @@
 
         <div class="govuk-button-group">
           {{ govukButton({
-          text: "Accept",
-          attributes: { "aria-label": "Accept - Review your agreement offer" },
+          text: "Accept offer",
+          attributes: { "aria-label": "Accept offer - Review your agreement offer" },
           value: "accepted",
           name: "offerStatus",
           preventDoubleClick: true
         }) }}
           {{ govukButton({
-          text: "Reject",
-          attributes: { "aria-label": "Reject - Review your agreement offer" },
+          text: "Reject offer",
+          attributes: { "aria-label": "Reject offer - Review your agreement offer" },
           classes: "govuk-button--secondary",
           value: "rejected",
           name: "offerStatus",

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -34,6 +34,8 @@ services:
       APIM_CLIENT_SECRET: ${APIM_CLIENT_SECRET:-changeme}
       APIM_SCOPE: ${APIM_SCOPE:-api://dev-futuretrade-int.defra.gov.uk/.default}
       TERMS_AND_CONDITIONS_URL: ${TERMS_AND_CONDITIONS_URL:-http://localhost:3003/terms/v3}
+      POULTRY_TERMS_AND_CONDITIONS_URL: ${POULTRY_TERMS_AND_CONDITIONS_URL:-https://www.gov.uk/government/publications/terms-and-conditions-poultry-biosecurity-review}
+      POULTRY_VET_SUMMARY_TEMPLATE_URL: ${POULTRY_VET_SUMMARY_TEMPLATE_URL:-https://www.gov.uk/guidance/vet-summary-template-for-poultry-biosecurity-reviews}
       MULTI_SPECIES_RELEASE_DATE: ${MULTI_SPECIES_RELEASE_DATE}
       CUSTOMER_SURVEY_CLAIM_URI: ${CUSTOMER_SURVEY_CLAIM_URI:-https://forms.office.com/e/SLKqfJQ499}
       CUSTOMER_SURVEY_APPLY_URI: ${CUSTOMER_SURVEY_APPLY_URI:-https://forms.office.com/e/4frXv6SqvR}

--- a/test/integration/narrow/routes/poultry/apply/declaration.test.js
+++ b/test/integration/narrow/routes/poultry/apply/declaration.test.js
@@ -33,6 +33,8 @@ jest.mock("../../../../../../app/config/index.js", () => ({
     ...jest.requireActual("../../../../../../app/config/index.js").config,
     poultry: {
       enabled: "true",
+      termsAndConditionsUri: "https://example.gov.uk/poultry-terms",
+      vetSummaryTemplateUri: "https://example.gov.uk/poultry-vet-summary",
     },
   },
 }));
@@ -110,19 +112,107 @@ describe("Declaration test", () => {
       expect(res.statusCode).toBe(StatusCodes.OK);
       expect(await axe(res.payload)).toHaveNoViolations();
       const $ = cheerio.load(res.payload);
-      expect($("h1").text()).toMatch("Review your agreement offer");
+      ok($);
+
       expect($("title").text()).toMatch(
         "Review your agreement offer - Get funding to improve animal health and welfare",
       );
-      ok($);
-      const expectedHerdsText = `If the RPA requests evidence that your biosecurity review took place, or details of the units you have, you must provide it. This will be on your vet summary.`;
-      const herdsText = $("p")
-        .filter((i, el) => {
-          return $(el).text().trim().startsWith("If the RPA requests evidence");
-        })
+      expect($("h1.govuk-heading-l").text().trim()).toBe("Review your agreement offer");
+
+      const intro = $("p")
+        .filter((i, el) =>
+          $(el).text().trim().startsWith("This is an offer of Poultry Biosecurity Review funding"),
+        )
         .first();
-      expect(herdsText.length).toBe(1);
-      expect(herdsText.text().trim()).toBe(expectedHerdsText);
+      expect(intro.text().trim()).toBe(
+        "This is an offer of Poultry Biosecurity Review funding for this business:",
+      );
+
+      expect($("#organisation-name").text()).toEqual(organisation.name);
+      expect($("#organisation-sbi").text()).toEqual(organisation.sbi);
+
+      const eitherHeading = $("h2:contains('You can either:')").first();
+      expect(eitherHeading.length).toBe(1);
+      const eitherBullets = eitherHeading
+        .nextAll("ul")
+        .first()
+        .find("li")
+        .map((i, el) => $(el).text().trim())
+        .get();
+      expect(eitherBullets).toEqual(["accept this offer", "reject this offer"]);
+
+      const mustHeading = $("h2:contains('For each review you must:')").first();
+      expect(mustHeading.length).toBe(1);
+      const mustBullets = mustHeading
+        .nextAll("ul")
+        .first()
+        .find("li")
+        .map((i, el) => $(el).text().trim().replace(/\s+/g, " "))
+        .get();
+      expect(mustBullets).toEqual([
+        "allow a vet to asses the biosecurity of the site being reviewed",
+        "share details about the vet with the Rural Payments Agency (RPA)",
+        "ensure the vet completes a poultry biosecurity review vet summary template (opens in new tab) as part of the review",
+      ]);
+
+      const askedHeading = $("h2:contains('If asked, you must provide the RPA with:')").first();
+      expect(askedHeading.length).toBe(1);
+      const askedBullets = askedHeading
+        .nextAll("ul")
+        .first()
+        .find("li")
+        .map((i, el) => $(el).text().trim())
+        .get();
+      expect(askedBullets).toEqual([
+        "evidence that your review took place",
+        "details of your poultry site",
+      ]);
+
+      const vetSummaryPara = $("p")
+        .filter((i, el) => $(el).text().trim() === "This information will be on your vet summary.")
+        .first();
+      expect(vetSummaryPara.length).toBe(1);
+
+      expect($("h2:contains('Declaration')").length).toBe(1);
+      const confirmPara = $("p")
+        .filter((i, el) => $(el).text().trim().startsWith("Confirm that you have read"))
+        .first();
+      expect(confirmPara.text().trim().replace(/\s+/g, " ")).toBe(
+        "Confirm that you have read the agreement terms and conditions (opens in new tab).",
+      );
+
+      const vetLink = $("#vetSummaryTemplateUri");
+      expect(vetLink.length).toBe(1);
+      expect(vetLink.attr("href")).toBe("https://example.gov.uk/poultry-vet-summary");
+      expect(vetLink.attr("target")).toBe("_blank");
+      expect(vetLink.attr("rel")).toMatch(/noopener/);
+      expect(vetLink.attr("rel")).toMatch(/noreferrer/);
+      expect(vetLink.text().trim()).toBe(
+        "poultry biosecurity review vet summary template (opens in new tab)",
+      );
+
+      const termsLink = $("#termsAndConditionsUri");
+      expect(termsLink.length).toBe(1);
+      expect(termsLink.attr("href")).toBe("https://example.gov.uk/poultry-terms");
+      expect(termsLink.attr("target")).toBe("_blank");
+      expect(termsLink.attr("rel")).toMatch(/noopener/);
+      expect(termsLink.attr("rel")).toMatch(/noreferrer/);
+      expect(termsLink.text().trim()).toBe("the agreement terms and conditions (opens in new tab)");
+
+      expect(res.payload).not.toContain(
+        "If the RPA requests evidence that your biosecurity review took place",
+      );
+      expect(res.payload).not.toContain("If you accept this offer you confirm that:");
+      expect(res.payload).not.toContain(
+        "The agreement terms and conditions include, but are not limited to:",
+      );
+      expect(res.payload).not.toContain("you must have the minimum number of poultry needed");
+      expect(res.payload).not.toContain(
+        "you must follow the rules for timing of biosecurity reviews",
+      );
+
+      expect($("button[value='accepted']").text().trim()).toBe("Accept offer");
+      expect($("button[value='rejected']").text().trim()).toBe("Reject offer");
     });
 
     test("redirects to dashboard when application exists", async () => {
@@ -277,6 +367,16 @@ describe("Declaration test", () => {
       expect($("#terms-error").text()).toMatch(
         "Confirm you have read and agree to the terms and conditions",
       );
+
+      const vetLink = $("#vetSummaryTemplateUri");
+      expect(vetLink.attr("href")).toBe("https://example.gov.uk/poultry-vet-summary");
+      expect(vetLink.attr("target")).toBe("_blank");
+      const termsLink = $("#termsAndConditionsUri");
+      expect(termsLink.attr("href")).toBe("https://example.gov.uk/poultry-terms");
+      expect(termsLink.attr("target")).toBe("_blank");
+      expect($("button[value='accepted']").text().trim()).toBe("Accept offer");
+      expect($("button[value='rejected']").text().trim()).toBe("Reject offer");
+
       expect(createApplication).not.toHaveBeenCalled();
       expect(refreshApplications).not.toHaveBeenCalled();
       expect(trackEvent).not.toHaveBeenCalled();

--- a/test/setup.js
+++ b/test/setup.js
@@ -3,6 +3,8 @@ import { config } from "dotenv";
 process.env.APPLICATION_API_URI = "http://ahwr-application-backend";
 process.env.COOKIE_PASSWORD = "test-55baf113-a8dc-4957-97e7-1f5340ace375";
 process.env.TERMS_AND_CONDITIONS_URL = "test";
+process.env.POULTRY_TERMS_AND_CONDITIONS_URL = "test";
+process.env.POULTRY_VET_SUMMARY_TEMPLATE_URL = "test";
 process.env.MESSAGE_QUEUE_HOST = "something.servicebus.windows.net";
 process.env.MESSAGE_QUEUE_USER = "message-queue-user";
 process.env.FCP_AHWR_EVENT_QUEUE_SA_KEY = "abcdefghijk123456";

--- a/test/unit/app/config/config.test.js
+++ b/test/unit/app/config/config.test.js
@@ -1,10 +1,10 @@
 import { getConfig } from "../../../../app/config/index.js";
 
 describe("Base config", () => {
-  const env = process.env;
+  const env = { ...process.env };
 
   afterEach(() => {
-    process.env = env;
+    process.env = { ...env };
   });
 
   test("environment variables used for overriding values", () => {
@@ -20,5 +20,15 @@ describe("Base config", () => {
     expect(() => getConfig()).toThrow(
       'The server config is invalid. "latestTermsAndConditionsUri" is required',
     );
+  });
+
+  test("should throw an error if poultry terms and conditions URL is missing", () => {
+    delete process.env.POULTRY_TERMS_AND_CONDITIONS_URL;
+    expect(() => getConfig()).toThrow(/poultry.*termsAndConditionsUri.*required/);
+  });
+
+  test("should throw an error if poultry vet summary template URL is missing", () => {
+    delete process.env.POULTRY_VET_SUMMARY_TEMPLATE_URL;
+    expect(() => getConfig()).toThrow(/poultry.*vetSummaryTemplateUri.*required/);
   });
 });


### PR DESCRIPTION
## Summary
Replaces the content of the Poultry "Review your agreement offer" screen with the latest Content Design copy. Adds two new external links, both opening in a new tab, and updates the call-to-action button labels. Functionality of the screen is unchanged.

## What Changed
- Rewrote the screen copy: revised intro line, "You can either" list, "For each review you must" list (with a new third bullet linking to the vet summary template), "If asked, you must provide the RPA with" list, and a new "Declaration" section
- Added a new external link to the gov.uk vet summary template guidance, opening in a new tab
- Updated the terms and conditions link to point at the new poultry-specific gov.uk publication, opening in a new tab
- Button labels changed from "Accept" and "Reject" to "Accept offer" and "Reject offer", with matching aria-labels
- Added two new required config keys for the poultry terms and conditions URL and the vet summary template URL, backed by environment variables
- Test coverage extended to assert all new content, link targets, link attributes, and button labels; accessibility checks retained via jest-axe (WCAG 2.2 AA)

## Why
Content Design has reworked the screen since it was first built. The new copy is clearer about what the farmer is signing up to, and the new vet summary template link is required for vets to complete a poultry biosecurity review.

The Livestock equivalent screen and its config are untouched.

The two new environment variables are added to CDP in a separate `cdp-app-config` [PR](https://github.com/DEFRA/cdp-app-config/pull/3523), which must merge and deploy first; this service will refuse to boot without them.

## Screenshot
<img width="895" height="1217" alt="Screenshot 2026-05-19 at 09 30 49" src="https://github.com/user-attachments/assets/89c6956e-e033-4cef-8e66-0791f31a74c9" />

