### PR TITLE
fix(AHWR-1850): scope poultry CPH check to poultry claims, align copy #patch

### DIFF
--- a/app/api-requests/claim-api.js
+++ b/app/api-requests/claim-api.js
@@ -65,8 +65,8 @@ export async function isURNUnique(data, logger) {
   }
 }
 
-export async function getClaimsCount(cph, herdId, logger) {
-  const params = new URLSearchParams({ cph });
+export async function getClaimsCount(cph, herdId, species, logger) {
+  const params = new URLSearchParams({ cph, species });
 
   if (herdId) {
     params.append("herdId", herdId);

--- a/app/api-requests/claim-api.js
+++ b/app/api-requests/claim-api.js
@@ -65,8 +65,8 @@ export async function isURNUnique(data, logger) {
   }
 }
 
-export async function getClaimsCount(cph, herdId, species, logger) {
-  const params = new URLSearchParams({ cph, species });
+export async function getClaimsCount(cph, herdId, scheme, logger) {
+  const params = new URLSearchParams({ cph, scheme });
 
   if (herdId) {
     params.append("herdId", herdId);

--- a/app/constants/claim-constants.js
+++ b/app/constants/claim-constants.js
@@ -62,6 +62,11 @@ export const ONLY_HERD_ON_SBI = {
   NO: "no",
 };
 
+export const SPECIES = {
+  POULTRY: "poultry",
+  LIVESTOCK: "livestock",
+};
+
 export const MULTIPLE_SPECIES_RELEASE_DATE = new Date("2025-02-26T00:00:00");
 export const MULTIPLE_HERDS_RELEASE_DATE = new Date("2025-06-26T00:00:00");
 export const PI_HUNT_AND_DAIRY_FOLLOW_UP_RELEASE_DATE = new Date("2025-01-21T00:00:00");

--- a/app/constants/claim-constants.js
+++ b/app/constants/claim-constants.js
@@ -62,11 +62,6 @@ export const ONLY_HERD_ON_SBI = {
   NO: "no",
 };
 
-export const SPECIES = {
-  POULTRY: "poultry",
-  LIVESTOCK: "livestock",
-};
-
 export const MULTIPLE_SPECIES_RELEASE_DATE = new Date("2025-02-26T00:00:00");
 export const MULTIPLE_HERDS_RELEASE_DATE = new Date("2025-06-26T00:00:00");
 export const PI_HUNT_AND_DAIRY_FOLLOW_UP_RELEASE_DATE = new Date("2025-01-21T00:00:00");

--- a/app/routes/poultry/claim/enter-cph-number.js
+++ b/app/routes/poultry/claim/enter-cph-number.js
@@ -8,7 +8,7 @@ import {
 } from "../../../session/index.js";
 import HttpStatus from "http-status-codes";
 import { poultryClaimRoutes, poultryClaimViews } from "../../../constants/routes.js";
-import { SPECIES } from "../../../constants/claim-constants.js";
+import { POULTRY_SCHEME } from "ffc-ahwr-common-library";
 import { normalizeCphNumber } from "../../../lib/cph-normalization.js";
 import { getClaimsCount } from "../../../api-requests/claim-api.js";
 
@@ -64,7 +64,7 @@ const postHandler = {
       const { herdCph } = request.payload;
       const { herds, herdId } = getSessionData(request, sessionEntryKeys.poultryClaim);
 
-      const response = await getClaimsCount(herdCph, herdId, SPECIES.POULTRY, request.logger);
+      const response = await getClaimsCount(herdCph, herdId, POULTRY_SCHEME, request.logger);
 
       if (response.count > 0) {
         return h

--- a/app/routes/poultry/claim/enter-cph-number.js
+++ b/app/routes/poultry/claim/enter-cph-number.js
@@ -8,6 +8,7 @@ import {
 } from "../../../session/index.js";
 import HttpStatus from "http-status-codes";
 import { poultryClaimRoutes, poultryClaimViews } from "../../../constants/routes.js";
+import { SPECIES } from "../../../constants/claim-constants.js";
 import { normalizeCphNumber } from "../../../lib/cph-normalization.js";
 import { getClaimsCount } from "../../../api-requests/claim-api.js";
 
@@ -50,7 +51,7 @@ const postHandler = {
           .view(poultryClaimViews.enterCphNumber, {
             ...request.payload,
             errorMessage: {
-              text: "Enter the CPH for this site in the format 12/345/6789",
+              text: "Enter the CPH for this site, format should be nn/nnn/nnnn",
               href: "#herdCph",
             },
             backLink: getBackLink(herdVersion),
@@ -63,14 +64,14 @@ const postHandler = {
       const { herdCph } = request.payload;
       const { herds, herdId } = getSessionData(request, sessionEntryKeys.poultryClaim);
 
-      const response = await getClaimsCount(herdCph, herdId, request.logger);
+      const response = await getClaimsCount(herdCph, herdId, SPECIES.POULTRY, request.logger);
 
       if (response.count > 0) {
         return h
           .view(poultryClaimViews.enterCphNumber, {
             ...request.payload,
             errorMessage: {
-              text: "Enter a CPH that you have not used for a different site",
+              text: "You have already used this CPH, the CPH must be unique",
               href: "#herdCph",
             },
             backLink: getBackLink(herds),

--- a/test/integration/narrow/routes/api-requests/claim-api.test.js
+++ b/test/integration/narrow/routes/api-requests/claim-api.test.js
@@ -6,6 +6,7 @@ import {
 } from "../../../../../app/api-requests/claim-api.js";
 import { config } from "../../../../../app/config/index.js";
 import { testWreckApiFunction } from "../../../../helpers/test-wreck-api.js";
+import { POULTRY_SCHEME } from "ffc-ahwr-common-library";
 
 jest.mock("@hapi/wreck");
 jest.mock("../../../../../app/logging/logger.js", () => ({
@@ -56,33 +57,33 @@ describe("claim api", () => {
     });
   });
 
-  test("getClaimsCount sends cph, species=poultry and herdId", async () => {
+  test("getClaimsCount sends cph, the poultry scheme and herdId", async () => {
     const params = new URLSearchParams({
       cph: "22/333/4444",
-      species: "poultry",
+      scheme: POULTRY_SCHEME,
       herdId: "e3d320b7-b2cf-469a-903f-ead7587d98e9",
     });
     await testWreckApiFunction({
       fn: getClaimsCount,
       method: "get",
       endpoint: `${config.applicationApiUri}/claims/count?${params.toString()}`,
-      args: ["22/333/4444", "e3d320b7-b2cf-469a-903f-ead7587d98e9", "poultry"],
+      args: ["22/333/4444", "e3d320b7-b2cf-469a-903f-ead7587d98e9", POULTRY_SCHEME],
       outboundPayload: null,
       returnPayload: { count: 2 },
       logger: makeLogger(),
     });
   });
 
-  test("getClaimsCount omits herdId when not supplied but still sends species=poultry", async () => {
+  test("getClaimsCount omits herdId when not supplied but still sends the poultry scheme", async () => {
     const params = new URLSearchParams({
       cph: "22/333/4444",
-      species: "poultry",
+      scheme: POULTRY_SCHEME,
     });
     await testWreckApiFunction({
       fn: getClaimsCount,
       method: "get",
       endpoint: `${config.applicationApiUri}/claims/count?${params.toString()}`,
-      args: ["22/333/4444", undefined, "poultry"],
+      args: ["22/333/4444", undefined, POULTRY_SCHEME],
       outboundPayload: null,
       returnPayload: { count: 0 },
       logger: makeLogger(),

--- a/test/integration/narrow/routes/api-requests/claim-api.test.js
+++ b/test/integration/narrow/routes/api-requests/claim-api.test.js
@@ -56,18 +56,35 @@ describe("claim api", () => {
     });
   });
 
-  test("getClaimsCount", async () => {
+  test("getClaimsCount sends cph, species=poultry and herdId", async () => {
     const params = new URLSearchParams({
       cph: "22/333/4444",
+      species: "poultry",
       herdId: "e3d320b7-b2cf-469a-903f-ead7587d98e9",
     });
     await testWreckApiFunction({
       fn: getClaimsCount,
       method: "get",
       endpoint: `${config.applicationApiUri}/claims/count?${params.toString()}`,
-      args: ["22/333/4444", "e3d320b7-b2cf-469a-903f-ead7587d98e9"],
+      args: ["22/333/4444", "e3d320b7-b2cf-469a-903f-ead7587d98e9", "poultry"],
       outboundPayload: null,
       returnPayload: { count: 2 },
+      logger: makeLogger(),
+    });
+  });
+
+  test("getClaimsCount omits herdId when not supplied but still sends species=poultry", async () => {
+    const params = new URLSearchParams({
+      cph: "22/333/4444",
+      species: "poultry",
+    });
+    await testWreckApiFunction({
+      fn: getClaimsCount,
+      method: "get",
+      endpoint: `${config.applicationApiUri}/claims/count?${params.toString()}`,
+      args: ["22/333/4444", undefined, "poultry"],
+      outboundPayload: null,
+      returnPayload: { count: 0 },
       logger: makeLogger(),
     });
   });

--- a/test/integration/narrow/routes/poultry/claim/enter-cph-number.test.js
+++ b/test/integration/narrow/routes/poultry/claim/enter-cph-number.test.js
@@ -13,6 +13,7 @@ import { when } from "jest-when";
 import { axe } from "../../../../../helpers/axe-helper.js";
 import { config } from "../../../../../../app/config/index.js";
 import { getClaimsCount } from "../../../../../../app/api-requests/claim-api.js";
+import { POULTRY_SCHEME } from "ffc-ahwr-common-library";
 
 jest.mock("../../../../../../app/session/index.js");
 jest.mock("../../../../../../app/api-requests/claim-api.js");
@@ -259,7 +260,7 @@ describe("/enter-cph-number tests", () => {
         expect(getClaimsCount).toHaveBeenCalledWith(
           "22/333/4444",
           "e3d320b7-b2cf-469a-903f-ead7587d98e9",
-          "poultry",
+          POULTRY_SCHEME,
           expect.any(Object),
         );
       });

--- a/test/integration/narrow/routes/poultry/claim/enter-cph-number.test.js
+++ b/test/integration/narrow/routes/poultry/claim/enter-cph-number.test.js
@@ -172,10 +172,10 @@ describe("/enter-cph-number tests", () => {
         expect(res.statusCode).toBe(400);
         expect($("h2.govuk-error-summary__title").text()).toContain("There is a problem");
         expect($('a[href="#herdCph"]').text()).toContain(
-          "Enter the CPH for this site in the format 12/345/6789",
+          "Enter the CPH for this site, format should be nn/nnn/nnnn",
         );
         expect($('p[id="herdCph-error"]').text()).toContain(
-          "Enter the CPH for this site in the format 12/345/6789",
+          "Enter the CPH for this site, format should be nn/nnn/nnnn",
         );
         expectSiteText($);
         expect(emitHerdEvent).not.toHaveBeenCalled();
@@ -199,10 +199,10 @@ describe("/enter-cph-number tests", () => {
         expect(res.statusCode).toBe(400);
         expect($("h2.govuk-error-summary__title").text()).toContain("There is a problem");
         expect($('a[href="#herdCph"]').text()).toContain(
-          "Enter the CPH for this site in the format 12/345/6789",
+          "Enter the CPH for this site, format should be nn/nnn/nnnn",
         );
         expect($('p[id="herdCph-error"]').text()).toContain(
-          "Enter the CPH for this site in the format 12/345/6789",
+          "Enter the CPH for this site, format should be nn/nnn/nnnn",
         );
         expectSiteText($);
         expect(emitHerdEvent).not.toHaveBeenCalled();
@@ -249,16 +249,17 @@ describe("/enter-cph-number tests", () => {
         expect(res.statusCode).toBe(400);
         expect($("h2.govuk-error-summary__title").text()).toContain("There is a problem");
         expect($('a[href="#herdCph"]').text()).toContain(
-          "Enter a CPH that you have not used for a different site",
+          "You have already used this CPH, the CPH must be unique",
         );
         expect($('p[id="herdCph-error"]').text()).toContain(
-          "Enter a CPH that you have not used for a different site",
+          "You have already used this CPH, the CPH must be unique",
         );
         expectSiteText($);
         expect(emitHerdEvent).not.toHaveBeenCalled();
         expect(getClaimsCount).toHaveBeenCalledWith(
           "22/333/4444",
           "e3d320b7-b2cf-469a-903f-ead7587d98e9",
+          "poultry",
           expect.any(Object),
         );
       });
@@ -283,10 +284,10 @@ describe("/enter-cph-number tests", () => {
       expect(res.statusCode).toBe(400);
       expect($("h2.govuk-error-summary__title").text()).toContain("There is a problem");
       expect($('a[href="#herdCph"]').text()).toContain(
-        "Enter the CPH for this site in the format 12/345/6789",
+        "Enter the CPH for this site, format should be nn/nnn/nnnn",
       );
       expect($('p[id="herdCph-error"]').text()).toContain(
-        "Enter the CPH for this site in the format 12/345/6789",
+        "Enter the CPH for this site, format should be nn/nnn/nnnn",
       );
       expectSiteText($);
       expect($(".govuk-back-link").attr("href")).toContain("/select-the-site");


### PR DESCRIPTION
## Summary
Fixes the Poultry "Enter CPH" screen so it no longer rejects CPHs that the same farmer has used in an existing Livestock claim. The screen now scopes its "already used" check to poultry claims only, and the error messages have been aligned with the wording specified by the ticket.

## What Changed
- Poultry CPH validation tells the backend to count poultry claims only, so Livestock history is ignored
- Uniqueness error message updated to "You have already used this CPH, the CPH must be unique"
- Empty-field and bad-format error messages updated to "Enter the CPH for this site, format should be nn/nnn/nnnn"
- Passes the poultry scheme to the claim-count call, reusing the common library's POULTRY_SCHEME constant rather than a locally defined value

## Why
A farmer with a Livestock claim against a given CPH could not previously make a Poultry claim for the same CPH on the same site, even though the two schemes are independent and the rules allow it. The on-screen error copy was also out of step with the ticket's specified wording. This change is the public UI half of the fix; the backend half (adding a scheme query parameter to /claims/count) needs to be live on the target environment before this merges.