### PR TITLE
fix(AHWR-1854): update select funding error to "Select a funding agreement" #patch

### DIFF
--- a/app/routes/select-funding.js
+++ b/app/routes/select-funding.js
@@ -50,7 +50,7 @@ export const selectFundingRouteHandlers = [
           fundingType: Joi.string()
             .valid("IAHW", "POUL")
             .required()
-            .messages({ "any.required": "Select a funding" }),
+            .messages({ "any.required": "Select a funding agreement" }),
         }),
         failAction: async (request, h, error) => {
           request.logger.error({ error });

--- a/test/integration/narrow/routes/select-funding.test.js
+++ b/test/integration/narrow/routes/select-funding.test.js
@@ -379,7 +379,7 @@ describe("select-funding", () => {
 
       expect(await axe(response.payload)).toHaveNoViolations();
       const $ = cheerio.load(response.payload);
-      const errorMessage = "Select a funding";
+      const errorMessage = "Select a funding agreement";
 
       expect($(".govuk-error-summary li > a").text()).toMatch(errorMessage);
       expect($(".govuk-error-message").text()).toContain(errorMessage);


### PR DESCRIPTION
## Summary
Updates the error-state content on the "Select funding" screen in the public UI. When a user presses Continue without choosing a funding option, the validation message now reads "Select a funding agreement" instead of "Select a funding".

## What Changed
- Reworded the no-selection validation message to "Select a funding agreement"
- Updated the corresponding integration test assertion to expect the new copy

## Why
The previous wording ("Select a funding") was grammatically incomplete and unclear about what the user is selecting. The new copy aligns with the agreed design and completes the content work started on the standard state of this screen. The message drives both the error summary link and the inline field error, so a single change covers both.

## Screenshot
<img width="903" height="792" alt="Screenshot 2026-05-21 at 09 44 14" src="https://github.com/user-attachments/assets/dfeaa067-264d-4f2c-abd2-346b073fa4d5" />
