### PR TITLE
feat(AHWR-1814): update Select Poultry Type content and chicken sub-type order #patch

### DIFF
--- a/app/views/poultry/claim/select-poultry-type.njk
+++ b/app/views/poultry/claim/select-poultry-type.njk
@@ -30,19 +30,19 @@
             errorMessage: errorMessageChicken,
             items: [
               {
+                value: "breeders",
+                text: "Breeders",
+                checked: typesOfChicken and "breeders" in typesOfChicken
+              },
+              {
                 value: "broilers",
                 text: "Broilers",
                 checked: typesOfChicken and "broilers" in typesOfChicken
               },
               {
                 value: "laying-hens",
-                text: "Laying hens",
+                text: "Laying hens (including pullets)",
                 checked: typesOfChicken and "laying-hens" in typesOfChicken
-              },
-              {
-                value: "breeders",
-                text: "Breeders",
-                checked: typesOfChicken and "breeders" in typesOfChicken
               }
             ]
           }) }}
@@ -53,13 +53,13 @@
           errorMessage: errorMessage,
           fieldset: {
           legend: {
-            text: "Which type of poultry do you keep on this site?",
+            text: "Which types of poultry do you keep on this site?",
             isPageHeading: true,
             classes: "govuk-fieldset__legend--l"
             }
           },
           hint: {
-            text: "Select all types of poultry you keep on this site"
+            text: "Select all poultry kept on this site"
           },
           items: [
             {

--- a/test/integration/narrow/routes/poultry/claim/select-poultry-type.test.js
+++ b/test/integration/narrow/routes/poultry/claim/select-poultry-type.test.js
@@ -83,6 +83,54 @@ describe("/poultry/select-poultry-type", () => {
       expect($("#back").attr("href")).toEqual("/poultry/site-others-on-sbi");
     });
 
+    test("shows the updated heading", async () => {
+      when(getSessionData)
+        .calledWith(expect.anything(), sessionEntryKeys.poultryClaim)
+        .mockReturnValue({ typesOfPoultry: [] });
+
+      const res = await server.inject({
+        method: "GET",
+        url,
+        auth,
+      });
+
+      const $ = cheerio.load(res.payload);
+      expect($("h1").text().trim()).toEqual("Which types of poultry do you keep on this site?");
+    });
+
+    test("shows the updated hint", async () => {
+      when(getSessionData)
+        .calledWith(expect.anything(), sessionEntryKeys.poultryClaim)
+        .mockReturnValue({ typesOfPoultry: [] });
+
+      const res = await server.inject({
+        method: "GET",
+        url,
+        auth,
+      });
+
+      const $ = cheerio.load(res.payload);
+      expect($(".govuk-hint").text().trim()).toEqual("Select all poultry kept on this site");
+    });
+
+    test("shows chicken sub-types in alphabetical order with the pullets label", async () => {
+      when(getSessionData)
+        .calledWith(expect.anything(), sessionEntryKeys.poultryClaim)
+        .mockReturnValue({ typesOfPoultry: ["chickens", "laying-hens"] });
+
+      const res = await server.inject({
+        method: "GET",
+        url,
+        auth,
+      });
+
+      const $ = cheerio.load(res.payload);
+      const subTypeLabels = $(".govuk-checkboxes__conditional .govuk-checkboxes__label")
+        .map((_, el) => $(el).text().trim())
+        .get();
+      expect(subTypeLabels).toEqual(["Breeders", "Broilers", "Laying hens (including pullets)"]);
+    });
+
     test("shows back link to select-the-site when no herds exist", async () => {
       when(getSessionData)
         .calledWith(expect.anything(), sessionEntryKeys.poultryClaim)


### PR DESCRIPTION
## Summary
Updates the content on the "Select Poultry Type" screen in the Make a Claim journey for the Poultry flavour, following a content review. This is a content-only change covering the page heading, hint text, and the chicken sub-type checkboxes. No functionality, validation, or data is affected.

## What Changed
- Page heading reworded to "Which types of poultry do you keep on this site?"
- Hint text reworded to "Select all poultry kept on this site"
- Chicken sub-types reordered alphabetically: Breeders, Broilers, Laying hens
- "Laying hens" checkbox label now reads "Laying hens (including pullets)" as a display label only; the stored value and the Check your answers screen are unchanged
- Added integration tests asserting the new heading, hint, and the reordered sub-type labels

## Why
The content for this screen was reviewed and updated after the original specification. The "(including pullets)" clarification helps farmers correctly identify their laying hens, and the alphabetical ordering improves scannability. Keeping the change to display labels only avoids any impact on stored claim data or downstream screens.