### PR TITLE
fix(AHWR-1828): correct select site url slug and update single-site content #patch

### DIFF
--- a/app/constants/routes.js
+++ b/app/constants/routes.js
@@ -201,7 +201,7 @@ export const poultryClaimRoutes = {
   interview: "/poultry/interview",
   minimumNumberOfBirds: "/poultry/minimum-number-of-birds",
   selectPoultryType: "/poultry/select-poultry-type",
-  selectTheSite: "/poultry/select-the-site",
+  selectTheSite: "/poultry/select-site",
   siteOthersOnSbi: "/poultry/site-others-on-sbi",
   vetName: "/poultry/vet-name",
   vetRcvs: "/poultry/vet-rcvs",

--- a/app/lib/build-poultry-claim-data.js
+++ b/app/lib/build-poultry-claim-data.js
@@ -1,5 +1,5 @@
 import { poultryClaimRoutes } from "../constants/routes.js";
-import { formatDate, upperFirstLetter } from "./display-helpers.js";
+import { formatDate, formatTypesOfPoultry, upperFirstLetter } from "./display-helpers.js";
 import { createdHerdRowObject, createImmutableRowObject } from "./generate-answer-rows.js";
 
 const biosecurityUsefulnessLabels = {
@@ -46,11 +46,9 @@ export const buildPoultryRows = ({ poultryClaim, organisation, herds }) => {
     poultryClaim,
   );
 
-  const filteredPoultryTypes = poultryClaim.typesOfPoultry.filter((type) => type !== "chickens");
-
   const typesOfPoultryRow = createdHerdRowObject(
     "Types of poultry",
-    upperFirstLetter(filteredPoultryTypes.join(", ").replace("-", " ")),
+    formatTypesOfPoultry(poultryClaim.typesOfPoultry),
     poultryClaimRoutes.selectPoultryType,
     "species",
   );

--- a/app/lib/display-helpers.js
+++ b/app/lib/display-helpers.js
@@ -32,6 +32,14 @@ export function upperFirstLetter(str) {
   return str.charAt(0).toUpperCase() + str.slice(1);
 }
 
+export const formatTypesOfPoultry = (typesOfPoultry) =>
+  upperFirstLetter(
+    (typesOfPoultry ?? [])
+      .filter((type) => type !== "chickens")
+      .join(", ")
+      .replaceAll("-", " "),
+  );
+
 export const formatDate = (date) =>
   new Date(date).toLocaleDateString("en-GB", { year: "numeric", month: "long", day: "numeric" });
 

--- a/app/lib/display-helpers.test.js
+++ b/app/lib/display-helpers.test.js
@@ -1,0 +1,27 @@
+import { formatTypesOfPoultry } from "./display-helpers.js";
+
+describe("formatTypesOfPoultry", () => {
+  it("capitalises the first letter and replaces dashes with spaces for a single type", () => {
+    expect(formatTypesOfPoultry(["laying-hens"])).toEqual("Laying hens");
+  });
+
+  it("joins multiple types with a comma and capitalises only the first letter", () => {
+    expect(formatTypesOfPoultry(["broilers", "laying-hens", "ducks"])).toEqual(
+      "Broilers, laying hens, ducks",
+    );
+  });
+
+  it("excludes the 'chickens' parent category", () => {
+    expect(formatTypesOfPoultry(["chickens", "broilers", "laying-hens"])).toEqual(
+      "Broilers, laying hens",
+    );
+  });
+
+  it("returns undefined for an empty array", () => {
+    expect(formatTypesOfPoultry([])).toBeUndefined();
+  });
+
+  it("returns undefined when given undefined", () => {
+    expect(formatTypesOfPoultry(undefined)).toBeUndefined();
+  });
+});

--- a/app/routes/poultry/claim/select-the-site.js
+++ b/app/routes/poultry/claim/select-the-site.js
@@ -70,7 +70,7 @@ const buildViewData = (previousClaims) => {
   const site = previousSites[0];
   return {
     backLink: poultryClaimRoutes.dateOfVisit,
-    pageTitleText: "Is this the same site you have previously claimed for?",
+    pageTitleText: "Your previous claim",
     siteId: site?.id,
     name: site?.name,
     sites: previousSites,

--- a/app/routes/poultry/claim/select-the-site.js
+++ b/app/routes/poultry/claim/select-the-site.js
@@ -7,7 +7,7 @@ import {
 } from "../../../session/index.js";
 import Joi from "joi";
 import HttpStatus from "http-status-codes";
-import { formatDate } from "../../../lib/display-helpers.js";
+import { formatDate, formatTypesOfPoultry } from "../../../lib/display-helpers.js";
 import { areDatesWithin10Months } from "../../../lib/utils.js";
 import { sendInvalidDataPoultryEvent } from "../../../messaging/ineligibility-event-emission.js";
 
@@ -33,7 +33,7 @@ const getUniqueSites = (previousClaims) => {
       id: claim.herd.id,
       name: claim.herd.name,
       cph: claim.herd.cph,
-      species: claim.data?.typesOfPoultry,
+      species: formatTypesOfPoultry(claim.data?.typesOfPoultry),
       lastVisitDate: claim.data?.dateOfVisit ? formatDate(claim.data.dateOfVisit) : undefined,
       claimDate: claim.createdAt ? formatDate(claim.createdAt) : undefined,
     }));

--- a/app/routes/poultry/vet-visits.js
+++ b/app/routes/poultry/vet-visits.js
@@ -5,7 +5,7 @@ import { poultryClaimRoutes } from "../../constants/routes.js";
 import { refreshApplications } from "../../lib/context-helper.js";
 import nunjucks from "nunjucks";
 import { getClaimsByApplicationReference } from "../../api-requests/claim-api.js";
-import { upperFirstLetter } from "../../lib/display-helpers.js";
+import { formatTypesOfPoultry } from "../../lib/display-helpers.js";
 
 const { latestTermsAndConditionsUri } = config;
 
@@ -22,9 +22,7 @@ const createRowsForTable = (claims) => {
       year: "numeric",
     });
 
-    const typesOfPoultry = upperFirstLetter(
-      claim.data.typesOfPoultry.join(", ").replaceAll("-", " "),
-    );
+    const typesOfPoultry = formatTypesOfPoultry(claim.data.typesOfPoultry);
 
     return [
       {

--- a/app/views/poultry/claim/select-the-site.njk
+++ b/app/views/poultry/claim/select-the-site.njk
@@ -26,18 +26,16 @@
         <input type="hidden" name="crumb" value="{{crumb}}"/>
 
         {% if sites.length == 1 %}
-          <h1 class="govuk-heading-l govuk-!-margin-bottom-2">{{ pageTitleText }}</h1>
-          <p class="govuk-hint govuk-!-margin-bottom-7">You can now have reviews and follow-ups on more than one site.</p>
-          <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-2">Your last claim for this species:</p>
-          {{ 
+          <h1 class="govuk-heading-l">{{ pageTitleText }}</h1>
+          {{
             govukSummaryList({
               rows: [
                 {
                   key: {
-                    text: "Species"
+                    text: "Types of poultry"
                   },
                   value: {
-                    text: species 
+                    text: species
                   }
                 },
                 {
@@ -79,16 +77,25 @@
             govukRadios({
               id: "siteSelected",
               name: "siteSelected",
+              fieldset: {
+                legend: {
+                  text: "Are you making another claim for the same site?",
+                  classes: "govuk-fieldset__legend--m"
+                }
+              },
+              hint: {
+                text: "You can have reviews on more than one site."
+              },
               errorMessage: errorMessage,
               items: [
                 {
                   value: siteId,
-                  text: "Yes, it's the same",
+                  text: "Yes, I'm claiming for the same site",
                   checked: siteSelected == siteId
                 },
                 {
                   value: radioValueNewSite,
-                  text: "No, it's a different site",
+                  text: "No, I'm claiming for a different site",
                   checked: siteSelected == radioValueNewSite
                 }
               ]

--- a/test/integration/narrow/routes/poultry/claim/date-of-visit.test.js
+++ b/test/integration/narrow/routes/poultry/claim/date-of-visit.test.js
@@ -245,7 +245,7 @@ describe("POST /poultry/date-of-visit", () => {
     const res = await server.inject(options);
 
     expect(res.statusCode).toBe(302);
-    expect(res.headers.location.toString()).toEqual("/poultry/select-the-site");
+    expect(res.headers.location.toString()).toEqual("/poultry/select-site");
     expect(setSessionData).toHaveBeenCalledWith(
       expect.anything(),
       sessionEntryKeys.poultryClaim,

--- a/test/integration/narrow/routes/poultry/claim/enter-cph-number.test.js
+++ b/test/integration/narrow/routes/poultry/claim/enter-cph-number.test.js
@@ -120,7 +120,7 @@ describe("/enter-cph-number tests", () => {
       expect(await axe(res.payload)).toHaveNoViolations();
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
-      expect($(".govuk-back-link").attr("href")).toContain("/select-the-site");
+      expect($(".govuk-back-link").attr("href")).toContain("/select-site");
       expectSiteText($);
       expectPhaseBanner.ok($);
     });
@@ -291,7 +291,7 @@ describe("/enter-cph-number tests", () => {
         "Enter the CPH for this site, format should be nn/nnn/nnnn",
       );
       expectSiteText($);
-      expect($(".govuk-back-link").attr("href")).toContain("/select-the-site");
+      expect($(".govuk-back-link").attr("href")).toContain("/select-site");
       expect(emitHerdEvent).not.toHaveBeenCalled();
     });
   });

--- a/test/integration/narrow/routes/poultry/claim/enter-site-name.test.js
+++ b/test/integration/narrow/routes/poultry/claim/enter-site-name.test.js
@@ -82,7 +82,7 @@ describe("/poultry/enter-site-name", () => {
       expect(await axe(res.payload)).toHaveNoViolations();
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
-      expect($(".govuk-back-link").attr("href")).toContain("/poultry/select-the-site");
+      expect($(".govuk-back-link").attr("href")).toContain("/poultry/select-site");
       expectSiteText($);
     });
 
@@ -105,7 +105,7 @@ describe("/poultry/enter-site-name", () => {
       expect(res.statusCode).toBe(200);
 
       const $ = cheerio.load(res.payload);
-      expect($(".govuk-back-link").attr("href")).toContain("/poultry/select-the-site");
+      expect($(".govuk-back-link").attr("href")).toContain("/poultry/select-site");
       expectSiteText($);
       expect($("#herdName").val()).toBe("Commercial Herd");
     });
@@ -202,7 +202,7 @@ describe("/poultry/enter-site-name", () => {
       expect(res.statusCode).toBe(400);
       expect($("h2.govuk-error-summary__title").text()).toContain("There is a problem");
       expect($('a[href="#herdName"]').text()).toContain("Enter the site name");
-      expect($(".govuk-back-link").attr("href")).toContain("/poultry/select-the-site");
+      expect($(".govuk-back-link").attr("href")).toContain("/poultry/select-site");
       expectSiteText($);
       expect(emitHerdEvent).not.toHaveBeenCalled();
     });
@@ -228,7 +228,7 @@ describe("/poultry/enter-site-name", () => {
       expect($('a[href="#herdName"]').text()).toContain(
         "Enter a site name of between 2 and 30 characters",
       );
-      expect($(".govuk-back-link").attr("href")).toContain("/poultry/select-the-site");
+      expect($(".govuk-back-link").attr("href")).toContain("/poultry/select-site");
       expectSiteText($);
       expect(emitHerdEvent).not.toHaveBeenCalled();
     });
@@ -254,7 +254,7 @@ describe("/poultry/enter-site-name", () => {
       expect($('a[href="#herdName"]').text()).toContain(
         "Enter a site name of between 2 and 30 characters",
       );
-      expect($(".govuk-back-link").attr("href")).toContain("/poultry/select-the-site");
+      expect($(".govuk-back-link").attr("href")).toContain("/poultry/select-site");
       expectSiteText($);
       expect(emitHerdEvent).not.toHaveBeenCalled();
     });
@@ -280,7 +280,7 @@ describe("/poultry/enter-site-name", () => {
       expect($('a[href="#herdName"]').text()).toContain(
         "Name must only include letters a to z, numbers and special characters such as hyphens, spaces and apostrophes.",
       );
-      expect($(".govuk-back-link").attr("href")).toContain("/poultry/select-the-site");
+      expect($(".govuk-back-link").attr("href")).toContain("/poultry/select-site");
       expectSiteText($);
       expect(emitHerdEvent).not.toHaveBeenCalled();
     });
@@ -313,7 +313,7 @@ describe("/poultry/enter-site-name", () => {
       expect($('a[href="#herdName"]').text()).toContain(
         "You have already used this name, the name must be unique",
       );
-      expect($(".govuk-back-link").attr("href")).toContain("/poultry/select-the-site");
+      expect($(".govuk-back-link").attr("href")).toContain("/poultry/select-site");
       expectSiteText($);
       expect(emitHerdEvent).not.toHaveBeenCalled();
     });

--- a/test/integration/narrow/routes/poultry/claim/select-poultry-type.test.js
+++ b/test/integration/narrow/routes/poultry/claim/select-poultry-type.test.js
@@ -160,7 +160,7 @@ describe("/poultry/select-poultry-type", () => {
 
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
-      expect($("#back").attr("href")).toEqual("/poultry/select-the-site");
+      expect($("#back").attr("href")).toEqual("/poultry/select-site");
     });
 
     test("handles undefined typesOfPoultry in session", async () => {

--- a/test/integration/narrow/routes/poultry/claim/select-the-site.test.js
+++ b/test/integration/narrow/routes/poultry/claim/select-the-site.test.js
@@ -13,12 +13,12 @@ import { axe } from "../../../../../helpers/axe-helper.js";
 import { sendInvalidDataPoultryEvent } from "../../../../../../app/messaging/ineligibility-event-emission.js";
 
 const auth = { credentials: { reference: "1111", sbi: "111111111" }, strategy: "cookie" };
-const url = "/poultry/select-the-site";
+const url = "/poultry/select-site";
 
 jest.mock("../../../../../../app/session/index.js");
 jest.mock("../../../../../../app/messaging/ineligibility-event-emission.js");
 
-describe("/poultry/select-the-site", () => {
+describe("/poultry/select-site", () => {
   let server;
 
   beforeAll(async () => {
@@ -82,7 +82,8 @@ describe("/poultry/select-the-site", () => {
       expect(await axe(res.payload)).toHaveNoViolations();
       const $ = cheerio.load(res.payload);
       expect($(".govuk-back-link").attr("href")).toContain("/poultry/date-of-visit");
-      expect($("title").text()).toContain("Is this the same site you have previously claimed for?");
+      expect($("title").text()).toContain("Your previous claim");
+      expect($("h1").text()).toContain("Your previous claim");
     });
 
     test("displays species, last visit date, and claim date for single site", async () => {
@@ -114,6 +115,72 @@ describe("/poultry/select-the-site", () => {
       expect(res.payload).toContain("Layers");
       expect(res.payload).toContain("15 March 2024");
       expect(res.payload).toContain("20 March 2024");
+    });
+
+    test("labels the previous claim summary with 'Types of poultry' for a single site", async () => {
+      when(getSessionData)
+        .calledWith(expect.anything(), sessionEntryKeys.poultryClaim)
+        .mockReturnValue({
+          siteSelected: null,
+          previousClaims: [
+            {
+              herd: {
+                id: "herd-123",
+                name: "Main Farm",
+                cph: "12/345/6789",
+              },
+              data: {
+                typesOfPoultry: "Layers",
+                dateOfVisit: "2024-03-15",
+              },
+              createdAt: "2024-03-20",
+            },
+          ],
+        });
+
+      const res = await server.inject({ method: "GET", url, auth });
+
+      expect(res.statusCode).toBe(200);
+      const $ = cheerio.load(res.payload);
+      expect($(".govuk-summary-list__key").first().text()).toContain("Types of poultry");
+      expect(res.payload).not.toContain("Your last claim for this species:");
+    });
+
+    test("asks whether claiming for the same site with the reworded question and options", async () => {
+      when(getSessionData)
+        .calledWith(expect.anything(), sessionEntryKeys.poultryClaim)
+        .mockReturnValue({
+          siteSelected: null,
+          previousClaims: [
+            {
+              herd: {
+                id: "herd-123",
+                name: "Main Farm",
+                cph: "12/345/6789",
+              },
+              data: {
+                typesOfPoultry: "Layers",
+                dateOfVisit: "2024-03-15",
+              },
+              createdAt: "2024-03-20",
+            },
+          ],
+        });
+
+      const res = await server.inject({ method: "GET", url, auth });
+
+      expect(res.statusCode).toBe(200);
+      const $ = cheerio.load(res.payload);
+      expect($(".govuk-fieldset__legend").text()).toContain(
+        "Are you making another claim for the same site?",
+      );
+      expect(res.payload).toContain("You can have reviews on more than one site.");
+      expect(res.payload).not.toContain(
+        "You can now have reviews and follow-ups on more than one site.",
+      );
+      const radioLabels = $(".govuk-radios__label").text();
+      expect(radioLabels).toContain("Yes, I'm claiming for the same site");
+      expect(radioLabels).toContain("No, I'm claiming for a different site");
     });
 
     test("returns 200 and displays page correctly with multiple previous sites", async () => {
@@ -260,7 +327,7 @@ describe("/poultry/select-the-site", () => {
 
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
-      expect($("title").text()).toContain("Is this the same site you have previously claimed for?");
+      expect($("title").text()).toContain("Your previous claim");
     });
 
     test("filters out claims without herd cph", async () => {
@@ -297,7 +364,7 @@ describe("/poultry/select-the-site", () => {
 
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
-      expect($("title").text()).toContain("Is this the same site you have previously claimed for?");
+      expect($("title").text()).toContain("Your previous claim");
     });
 
     test("returns unique sites when duplicate name/cph combinations exist", async () => {
@@ -380,7 +447,7 @@ describe("/poultry/select-the-site", () => {
 
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
-      expect($("title").text()).toContain("Is this the same site you have previously claimed for?");
+      expect($("title").text()).toContain("Your previous claim");
     });
 
     test("preserves previously selected site", async () => {
@@ -429,7 +496,7 @@ describe("/poultry/select-the-site", () => {
 
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
-      expect($("title").text()).toContain("Is this the same site you have previously claimed for?");
+      expect($("title").text()).toContain("Your previous claim");
       expect(res.payload).toContain("Main Farm");
       expect(res.payload).toContain("12/345/6789");
     });
@@ -875,7 +942,7 @@ describe("/poultry/select-the-site", () => {
       expect(res.statusCode).toBe(400);
       const $ = cheerio.load(res.payload);
       expect($("h1").text()).toContain("You cannot continue with your claim");
-      expect($(".govuk-back-link").attr("href")).toEqual("/poultry/select-the-site");
+      expect($(".govuk-back-link").attr("href")).toEqual("/poultry/select-site");
       expect(sendInvalidDataPoultryEvent).toHaveBeenCalledWith({
         request: expect.anything(),
         sessionKey: sessionKeys.poultryClaim.dateOfVisit,
@@ -917,7 +984,7 @@ describe("/poultry/select-the-site", () => {
       expect(res.statusCode).toBe(400);
       const $ = cheerio.load(res.payload);
       expect($("h1").text()).toContain("You cannot continue with your claim");
-      expect($(".govuk-back-link").attr("href")).toEqual("/poultry/select-the-site");
+      expect($(".govuk-back-link").attr("href")).toEqual("/poultry/select-site");
       expect(sendInvalidDataPoultryEvent).toHaveBeenCalledWith({
         request: expect.anything(),
         sessionKey: sessionKeys.poultryClaim.dateOfVisit,

--- a/test/integration/narrow/routes/poultry/claim/select-the-site.test.js
+++ b/test/integration/narrow/routes/poultry/claim/select-the-site.test.js
@@ -68,7 +68,7 @@ describe("/poultry/select-site", () => {
                 cph: "12/345/6789",
               },
               data: {
-                typesOfPoultry: "Layers",
+                typesOfPoultry: ["laying-hens"],
                 dateOfVisit: "2024-03-15",
               },
               createdAt: "2024-03-20",
@@ -99,7 +99,7 @@ describe("/poultry/select-site", () => {
                 cph: "12/345/6789",
               },
               data: {
-                typesOfPoultry: "Layers",
+                typesOfPoultry: ["laying-hens"],
                 dateOfVisit: "2024-03-15",
               },
               createdAt: "2024-03-20",
@@ -112,7 +112,7 @@ describe("/poultry/select-site", () => {
       expect(res.statusCode).toBe(200);
       expect(res.payload).toContain("Main Farm");
       expect(res.payload).toContain("12/345/6789");
-      expect(res.payload).toContain("Layers");
+      expect(res.payload).toContain("Laying hens");
       expect(res.payload).toContain("15 March 2024");
       expect(res.payload).toContain("20 March 2024");
     });
@@ -130,7 +130,7 @@ describe("/poultry/select-site", () => {
                 cph: "12/345/6789",
               },
               data: {
-                typesOfPoultry: "Layers",
+                typesOfPoultry: ["laying-hens"],
                 dateOfVisit: "2024-03-15",
               },
               createdAt: "2024-03-20",
@@ -159,7 +159,7 @@ describe("/poultry/select-site", () => {
                 cph: "12/345/6789",
               },
               data: {
-                typesOfPoultry: "Layers",
+                typesOfPoultry: ["laying-hens"],
                 dateOfVisit: "2024-03-15",
               },
               createdAt: "2024-03-20",
@@ -183,6 +183,36 @@ describe("/poultry/select-site", () => {
       expect(radioLabels).toContain("No, I'm claiming for a different site");
     });
 
+    test("formats the types of poultry as a capitalised, comma-separated list excluding chickens", async () => {
+      when(getSessionData)
+        .calledWith(expect.anything(), sessionEntryKeys.poultryClaim)
+        .mockReturnValue({
+          siteSelected: null,
+          previousClaims: [
+            {
+              herd: {
+                id: "herd-123",
+                name: "Main Farm",
+                cph: "12/345/6789",
+              },
+              data: {
+                typesOfPoultry: ["chickens", "broilers", "laying-hens", "ducks"],
+                dateOfVisit: "2024-03-15",
+              },
+              createdAt: "2024-03-20",
+            },
+          ],
+        });
+
+      const res = await server.inject({ method: "GET", url, auth });
+
+      expect(res.statusCode).toBe(200);
+      const $ = cheerio.load(res.payload);
+      expect($(".govuk-summary-list__value").first().text()).toContain(
+        "Broilers, laying hens, ducks",
+      );
+    });
+
     test("returns 200 and displays page correctly with multiple previous sites", async () => {
       when(getSessionData)
         .calledWith(expect.anything(), sessionEntryKeys.poultryClaim)
@@ -196,7 +226,7 @@ describe("/poultry/select-site", () => {
                 cph: "12/345/6789",
               },
               data: {
-                typesOfPoultry: "Layers",
+                typesOfPoultry: ["laying-hens"],
                 dateOfVisit: "2024-03-15",
               },
               createdAt: "2024-03-20",
@@ -208,7 +238,7 @@ describe("/poultry/select-site", () => {
                 cph: "98/765/4321",
               },
               data: {
-                typesOfPoultry: "Broilers",
+                typesOfPoultry: ["broilers"],
                 dateOfVisit: "2024-02-10",
               },
               createdAt: "2024-02-15",
@@ -238,7 +268,7 @@ describe("/poultry/select-site", () => {
                 cph: "12/345/6789",
               },
               data: {
-                typesOfPoultry: "Layers",
+                typesOfPoultry: ["laying-hens"],
                 dateOfVisit: "2024-03-15",
               },
               createdAt: "2024-03-20",
@@ -250,7 +280,7 @@ describe("/poultry/select-site", () => {
                 cph: "98/765/4321",
               },
               data: {
-                typesOfPoultry: "Broilers",
+                typesOfPoultry: ["broilers"],
                 dateOfVisit: "2024-02-10",
               },
               createdAt: "2024-02-15",
@@ -306,7 +336,7 @@ describe("/poultry/select-site", () => {
                 cph: "12/345/6789",
               },
               data: {
-                typesOfPoultry: "Layers",
+                typesOfPoultry: ["laying-hens"],
                 dateOfVisit: "2024-03-15",
               },
               createdAt: "2024-03-20",
@@ -317,7 +347,7 @@ describe("/poultry/select-site", () => {
                 cph: "98/765/4321",
               },
               data: {
-                typesOfPoultry: "Broilers",
+                typesOfPoultry: ["broilers"],
               },
             },
           ],
@@ -343,7 +373,7 @@ describe("/poultry/select-site", () => {
                 cph: "12/345/6789",
               },
               data: {
-                typesOfPoultry: "Layers",
+                typesOfPoultry: ["laying-hens"],
                 dateOfVisit: "2024-03-15",
               },
               createdAt: "2024-03-20",
@@ -354,7 +384,7 @@ describe("/poultry/select-site", () => {
                 name: "Second Farm",
               },
               data: {
-                typesOfPoultry: "Broilers",
+                typesOfPoultry: ["broilers"],
               },
             },
           ],
@@ -380,7 +410,7 @@ describe("/poultry/select-site", () => {
                 cph: "12/345/6789",
               },
               data: {
-                typesOfPoultry: "Layers",
+                typesOfPoultry: ["laying-hens"],
                 dateOfVisit: "2024-03-15",
               },
               createdAt: "2024-03-20",
@@ -392,7 +422,7 @@ describe("/poultry/select-site", () => {
                 cph: "12/345/6789",
               },
               data: {
-                typesOfPoultry: "Layers",
+                typesOfPoultry: ["laying-hens"],
                 dateOfVisit: "2024-01-10",
               },
               createdAt: "2024-01-15",
@@ -404,7 +434,7 @@ describe("/poultry/select-site", () => {
                 cph: "98/765/4321",
               },
               data: {
-                typesOfPoultry: "Broilers",
+                typesOfPoultry: ["broilers"],
                 dateOfVisit: "2024-02-10",
               },
               createdAt: "2024-02-15",
@@ -432,13 +462,13 @@ describe("/poultry/select-site", () => {
                 cph: "12/345/6789",
               },
               data: {
-                typesOfPoultry: "Layers",
+                typesOfPoultry: ["laying-hens"],
                 dateOfVisit: "2024-03-15",
               },
               createdAt: "2024-03-20",
             },
             {
-              data: { typesOfPoultry: "Broilers" },
+              data: { typesOfPoultry: ["broilers"] },
             },
           ],
         });
@@ -463,7 +493,7 @@ describe("/poultry/select-site", () => {
                 cph: "12/345/6789",
               },
               data: {
-                typesOfPoultry: "Layers",
+                typesOfPoultry: ["laying-hens"],
                 dateOfVisit: "2024-03-15",
               },
               createdAt: "2024-03-20",
@@ -523,7 +553,7 @@ describe("/poultry/select-site", () => {
                 cph: "12/345/6789",
               },
               data: {
-                typesOfPoultry: "Layers",
+                typesOfPoultry: ["laying-hens"],
                 dateOfVisit: "2024-03-15",
               },
               createdAt: "2024-03-20",
@@ -593,7 +623,7 @@ describe("/poultry/select-site", () => {
                 cph: "12/345/6789",
               },
               data: {
-                typesOfPoultry: "Layers",
+                typesOfPoultry: ["laying-hens"],
                 dateOfVisit: "2024-03-15",
               },
               createdAt: "2024-03-20",
@@ -605,7 +635,7 @@ describe("/poultry/select-site", () => {
                 cph: "98/765/4321",
               },
               data: {
-                typesOfPoultry: "Broilers",
+                typesOfPoultry: ["broilers"],
                 dateOfVisit: "2024-02-10",
               },
               createdAt: "2024-02-15",
@@ -673,7 +703,7 @@ describe("/poultry/select-site", () => {
                 cph: "12/345/6789",
               },
               data: {
-                typesOfPoultry: "Layers",
+                typesOfPoultry: ["laying-hens"],
                 dateOfVisit: "2024-03-15",
               },
               createdAt: "2024-03-20",
@@ -710,7 +740,7 @@ describe("/poultry/select-site", () => {
                 cph: "12/345/6789",
               },
               data: {
-                typesOfPoultry: "Layers",
+                typesOfPoultry: ["laying-hens"],
                 dateOfVisit: "2024-03-15",
               },
               createdAt: "2024-03-20",
@@ -722,7 +752,7 @@ describe("/poultry/select-site", () => {
                 cph: "98/765/4321",
               },
               data: {
-                typesOfPoultry: "Broilers",
+                typesOfPoultry: ["broilers"],
                 dateOfVisit: "2024-02-10",
               },
               createdAt: "2024-02-15",
@@ -759,7 +789,7 @@ describe("/poultry/select-site", () => {
                 cph: "12/345/6789",
               },
               data: {
-                typesOfPoultry: "Layers",
+                typesOfPoultry: ["laying-hens"],
                 dateOfVisit: "2024-03-15",
               },
               createdAt: "2024-03-20",
@@ -834,7 +864,7 @@ describe("/poultry/select-site", () => {
                 cph: "12/345/6789",
               },
               data: {
-                typesOfPoultry: "Layers",
+                typesOfPoultry: ["laying-hens"],
                 dateOfVisit: "2024-03-15",
               },
               createdAt: "2024-03-20",
@@ -846,7 +876,7 @@ describe("/poultry/select-site", () => {
                 cph: "98/765/4321",
               },
               data: {
-                typesOfPoultry: "Broilers",
+                typesOfPoultry: ["broilers"],
                 dateOfVisit: "2024-02-10",
               },
               createdAt: "2024-02-15",
@@ -923,7 +953,7 @@ describe("/poultry/select-site", () => {
                 cph: "12/345/6789",
               },
               data: {
-                typesOfPoultry: "Layers",
+                typesOfPoultry: ["laying-hens"],
                 dateOfVisit: "2025-01-01",
               },
               createdAt: "2025-01-05",
@@ -965,7 +995,7 @@ describe("/poultry/select-site", () => {
                 cph: "12/345/6789",
               },
               data: {
-                typesOfPoultry: "Layers",
+                typesOfPoultry: ["laying-hens"],
                 dateOfVisit: "2025-01-01",
               },
               createdAt: "2025-01-05",
@@ -1006,7 +1036,7 @@ describe("/poultry/select-site", () => {
                 cph: "12/345/6789",
               },
               data: {
-                typesOfPoultry: "Layers",
+                typesOfPoultry: ["laying-hens"],
                 dateOfVisit: "2025-01-01",
               },
               createdAt: "2025-01-05",
@@ -1040,7 +1070,7 @@ describe("/poultry/select-site", () => {
                 cph: "12/345/6789",
               },
               data: {
-                typesOfPoultry: "Layers",
+                typesOfPoultry: ["laying-hens"],
                 dateOfVisit: "2025-01-01",
               },
               createdAt: "2025-01-05",
@@ -1052,7 +1082,7 @@ describe("/poultry/select-site", () => {
                 cph: "98/765/4321",
               },
               data: {
-                typesOfPoultry: "Broilers",
+                typesOfPoultry: ["broilers"],
                 dateOfVisit: "2024-01-01",
               },
               createdAt: "2024-01-05",

--- a/test/integration/narrow/routes/poultry/vet-visits.test.js
+++ b/test/integration/narrow/routes/poultry/vet-visits.test.js
@@ -191,7 +191,15 @@ describe("GET /vet-visits", () => {
         type: "REVIEW",
         data: {
           dateOfVisit: "2026-04-21T00:00:00.000Z",
-          typesOfPoultry: ["broilers", "laying-hens", "breeders", "ducks", "geese", "turkeys"],
+          typesOfPoultry: [
+            "chickens",
+            "broilers",
+            "laying-hens",
+            "breeders",
+            "ducks",
+            "geese",
+            "turkeys",
+          ],
           minimumNumberOfBirds: "yes",
           vetsName: "Vet 1",
           vetRCVSNumber: "1234567",
@@ -269,6 +277,7 @@ describe("GET /vet-visits", () => {
       ],
       ["4 June 2026", "site two", "Broilers, laying hens", "PORE-D51M-ABCJ", "Paid"],
     ]);
+    expect($("body").text()).not.toContain("Chickens");
     expect($("body").text()).not.toContain("You have not submitted any claims yet.");
     expect(await axe(res.payload)).toHaveNoViolations();
   });


### PR DESCRIPTION
## Summary
Corrects the URL slug and refreshes the on-screen content for the poultry "Select Site" screen in the Make a Claim journey, for the case where a single previous site has been claimed against the SBI. The slug correction applies to all variants of the screen; the content update is limited to the single-previous-site state.

It also fixes how the poultry types are displayed on that screen, and consolidates that formatting into one shared helper used everywhere the value appears.

## What Changed
- The screen's URL slug now reads `/poultry/select-site` (previously `/poultry/select-the-site`), across all variants. Internal redirects and back links follow automatically.
- Single-previous-site screen content updated to match the agreed design:
  - Page heading is now "Your previous claim"
  - Removed the "Your last claim for this species:" sub-heading
  - The hint now reads "You can have reviews on more than one site." and sits with the question
  - Summary list label "Species" renamed to "Types of poultry"
  - The yes/no question "Are you making another claim for the same site?" is now a proper fieldset legend, with reworded options "Yes, I'm claiming for the same site" and "No, I'm claiming for a different site"
- The list of poultry types now displays as readable text (capitalised, comma-separated, with the internal "chickens" grouping category excluded) instead of the raw stored values. Previously this screen showed something like "ducks,breeders".
- That formatting is now provided by a single shared helper and reused on the Check Answers and "Manage your claims" screens, replacing three near-identical copies. As a result, the "Manage your claims" table now also excludes the redundant "chickens" grouping category, bringing it in line with the Check Answers screen.
- Tests updated for the new slug and content, with added coverage for the revised single-site copy and the poultry-type formatting.

## Why
The slug was built incorrectly when the screen was first delivered, and the content has since been reviewed and updated. The poultry types were rendering as a raw, unformatted value on this screen, and the same formatting was duplicated in three places with one copy behaving slightly differently. Consolidating it removes the duplication and keeps the three screens consistent. The multi-site variant, screen functionality, and error states are unchanged.

## Screenshot
<img width="1219" height="850" alt="Screenshot 2026-05-21 at 15 54 44" src="https://github.com/user-attachments/assets/df8fb33e-8a73-490e-940b-c4c3fbeac5f5" />


