### PR TITLE
feat(claims): update minimum number of birds screen content (AHWR-1880) #patch

### DIFF
--- a/app/views/poultry/claim/minimum-number-of-birds.njk
+++ b/app/views/poultry/claim/minimum-number-of-birds.njk
@@ -32,12 +32,12 @@
               legend:{
                 isPageHeading: true,
                 classes: "govuk-fieldset__legend--l",
-                text: 'Has your vet confirmed that this site has the capacity to hold the minimum number of birds?'
+                text: 'Has your vet confirmed that this site can hold the minimum number of birds?'
               }
-            }, 
+            },
             hint: {
-              html: "You might not have any birds at the time of the review. You need to confirm the site can hold the minimum number of birds. You only need to meet the minimum number for one species.</br></br>Minimum number of birds per species:<ul><li>1,000 broilers</li><li>1,000 laying hens</li><li>1,000 breeders</li><li>500 ducks</li><li>500 geese</li><li>500 turkeys</li></ul>"
-            }, 
+              html: "The minimum numbers of birds are:<ul><li>1,000 broiler chickens</li><li>1,000 breeder chickens</li><li>1,000 laying hens (including pullets)</li><li>500 ducks</li><li>500 geese</li><li>500 turkeys</li></ul>You only need to meet the minimum number for one type of poultry."
+            },
             errorMessage: errorMessage,
             items: [
               {

--- a/test/integration/narrow/routes/poultry/claim/minimum-number-of-birds.test.js
+++ b/test/integration/narrow/routes/poultry/claim/minimum-number-of-birds.test.js
@@ -89,8 +89,28 @@ describe("/poultry/minimum-number-of-birds tests", () => {
       expect($("#back").attr("href")).toContain("/select-poultry-type");
       const legend = $(".govuk-fieldset__legend--l");
       expect(legend.text().trim()).toBe(
-        "Has your vet confirmed that this site has the capacity to hold the minimum number of birds?",
+        "Has your vet confirmed that this site can hold the minimum number of birds?",
       );
+
+      const hint = $(".govuk-hint");
+      expect(hint.text()).toContain("The minimum numbers of birds are:");
+      const birdNumbers = hint
+        .find("li")
+        .map((_, el) => $(el).text().trim())
+        .get();
+      expect(birdNumbers).toEqual([
+        "1,000 broiler chickens",
+        "1,000 breeder chickens",
+        "1,000 laying hens (including pullets)",
+        "500 ducks",
+        "500 geese",
+        "500 turkeys",
+      ]);
+      expect(hint.text()).toContain(
+        "You only need to meet the minimum number for one type of poultry.",
+      );
+      expect(hint.text()).not.toContain("You might not have any birds");
+
       expectPhaseBanner.ok($);
     });
 


### PR DESCRIPTION
## Summary
Updates the content on the poultry claim "Minimum number of birds" screen to the wording agreed during content review. This is a content-only change covering the screen heading and hint text; screen functionality is unchanged.

## What Changed
- Reworded the screen heading to ask whether the vet has confirmed the site can hold the minimum number of birds.
- Rewrote the hint: introduces the bird-number list with "The minimum numbers of birds are:", updates the species wording and order (broiler chickens, breeder chickens, laying hens including pullets, ducks, geese, turkeys), and moves the "one type of poultry" note below the list.
- Removed the obsolete "you might not have any birds at the time of the review" introduction.
- Updated the screen's integration test to assert the new heading and hint content.

## Why
The screen content was reviewed after the original build and needs to reflect the approved copy. The error-state wording was already delivered as part of an earlier error-messages change, so no error-state code was needed here; it is covered by regression and the existing test.