### PR TITLE
fix(poultry): drop "yes" from radio-group error wording (AHWR-1916, AHWR-1918) #patch

### DIFF
--- a/app/routes/poultry/claim/biosecurity.js
+++ b/app/routes/poultry/claim/biosecurity.js
@@ -9,7 +9,7 @@ import { poultryClaimViews, poultryClaimRoutes } from "../../../constants/routes
 import HttpStatus from "http-status-codes";
 import { sendInvalidDataPoultryEvent } from "../../../messaging/ineligibility-event-emission.js";
 
-const YES_TO_ASSESSMENT_TEXT = "Select yes if the vet did a biosecurity assessment";
+const YES_TO_ASSESSMENT_TEXT = "Select if the vet did a biosecurity assessment";
 
 const getHandler = {
   method: "GET",

--- a/app/routes/poultry/claim/site-others-on-sbi.js
+++ b/app/routes/poultry/claim/site-others-on-sbi.js
@@ -38,7 +38,7 @@ const postHandler = {
           .view(poultryClaimViews.siteOthersOnSbi, {
             ...request.payload,
             errorMessage: {
-              text: `Select yes if this is the only site associated with this SBI`,
+              text: `Select if this is the only site associated with this SBI`,
               href: "#isOnlyHerdOnSbi",
             },
             backLink: poultryClaimRoutes.enterCphNumber,

--- a/test/integration/narrow/routes/poultry/claim/biosecurity.test.js
+++ b/test/integration/narrow/routes/poultry/claim/biosecurity.test.js
@@ -148,7 +148,7 @@ describe("/poultry/biosecurity", () => {
 
         expect(await axe(response.payload)).toHaveNoViolations();
         const $ = cheerio.load(response.payload);
-        const errorMessage = "Select yes if the vet did a biosecurity assessment";
+        const errorMessage = "Select if the vet did a biosecurity assessment";
 
         expect($("li > a").text()).toMatch(errorMessage);
       });

--- a/test/integration/narrow/routes/poultry/claim/site-others-on-sbi.test.js
+++ b/test/integration/narrow/routes/poultry/claim/site-others-on-sbi.test.js
@@ -214,7 +214,7 @@ describe("/site-others-on-sbi tests", () => {
       expect(res.statusCode).toBe(400);
       expect($("h2.govuk-error-summary__title").text()).toContain("There is a problem");
       expect($('a[href="#isOnlyHerdOnSbi"]').text()).toContain(
-        "Select yes if this is the only site associated with this SBI",
+        "Select if this is the only site associated with this SBI",
       );
       expect($("title").text().trim()).toContain(
         "Is this the only site associated with this Single Business Identifier (SBI)? - Get funding to improve animal health and welfare - GOV.UKGOV.UK",


### PR DESCRIPTION
## Summary
Two small content corrections to radio-group error messages on the Poultry claim journey. Both screens previously prefixed their "did you do X" error with the word "yes", which design flagged as incorrect copy during walkthrough. Matching test assertions updated alongside.

## What Changed
- Updated the error wording shown when the user submits the "is this the only site associated with this SBI?" form without picking an option.
- Updated the error wording shown when the user submits the "did the vet do a biosecurity assessment?" form without picking an option.
- Updated the integration test assertions for both screens to expect the corrected wording.

## Why
Both wordings were flagged as incorrect during the post-launch design walkthrough. Dropping the leading "yes" aligns the error copy with the agreed pattern for radio-group validation messages. Patch-level change: no behavioural impact beyond the visible copy fix, no consumers affected.

## Screenshots
<img width="895" height="675" alt="Screenshot 2026-06-01 at 11 28 07" src="https://github.com/user-attachments/assets/5c051a28-6c72-47dd-92cf-8e047af7d559" />
<img width="904" height="670" alt="Screenshot 2026-06-01 at 11 28 52" src="https://github.com/user-attachments/assets/e4291016-9e76-4dda-a911-399cd2bf2f95" />

