### PR TITLE
fix(poultry): align enter cph error wording with spec (AHWR-1915) #patch

### DIFF
--- a/app/routes/poultry/claim/enter-cph-number.js
+++ b/app/routes/poultry/claim/enter-cph-number.js
@@ -51,7 +51,7 @@ const postHandler = {
           .view(poultryClaimViews.enterCphNumber, {
             ...request.payload,
             errorMessage: {
-              text: "Enter the CPH for this site, format should be nn/nnn/nnnn",
+              text: "Enter the CPH for this site in the format 12/345/6789",
               href: "#herdCph",
             },
             backLink: getBackLink(herdVersion),
@@ -71,7 +71,7 @@ const postHandler = {
           .view(poultryClaimViews.enterCphNumber, {
             ...request.payload,
             errorMessage: {
-              text: "You have already used this CPH, the CPH must be unique",
+              text: "Enter a CPH that you have not used for a different site",
               href: "#herdCph",
             },
             backLink: getBackLink(herds),

--- a/test/integration/narrow/routes/poultry/claim/enter-cph-number.test.js
+++ b/test/integration/narrow/routes/poultry/claim/enter-cph-number.test.js
@@ -173,10 +173,10 @@ describe("/enter-cph-number tests", () => {
         expect(res.statusCode).toBe(400);
         expect($("h2.govuk-error-summary__title").text()).toContain("There is a problem");
         expect($('a[href="#herdCph"]').text()).toContain(
-          "Enter the CPH for this site, format should be nn/nnn/nnnn",
+          "Enter the CPH for this site in the format 12/345/6789",
         );
         expect($('p[id="herdCph-error"]').text()).toContain(
-          "Enter the CPH for this site, format should be nn/nnn/nnnn",
+          "Enter the CPH for this site in the format 12/345/6789",
         );
         expectSiteText($);
         expect(emitHerdEvent).not.toHaveBeenCalled();
@@ -200,10 +200,10 @@ describe("/enter-cph-number tests", () => {
         expect(res.statusCode).toBe(400);
         expect($("h2.govuk-error-summary__title").text()).toContain("There is a problem");
         expect($('a[href="#herdCph"]').text()).toContain(
-          "Enter the CPH for this site, format should be nn/nnn/nnnn",
+          "Enter the CPH for this site in the format 12/345/6789",
         );
         expect($('p[id="herdCph-error"]').text()).toContain(
-          "Enter the CPH for this site, format should be nn/nnn/nnnn",
+          "Enter the CPH for this site in the format 12/345/6789",
         );
         expectSiteText($);
         expect(emitHerdEvent).not.toHaveBeenCalled();
@@ -250,10 +250,10 @@ describe("/enter-cph-number tests", () => {
         expect(res.statusCode).toBe(400);
         expect($("h2.govuk-error-summary__title").text()).toContain("There is a problem");
         expect($('a[href="#herdCph"]').text()).toContain(
-          "You have already used this CPH, the CPH must be unique",
+          "Enter a CPH that you have not used for a different site",
         );
         expect($('p[id="herdCph-error"]').text()).toContain(
-          "You have already used this CPH, the CPH must be unique",
+          "Enter a CPH that you have not used for a different site",
         );
         expectSiteText($);
         expect(emitHerdEvent).not.toHaveBeenCalled();
@@ -285,10 +285,10 @@ describe("/enter-cph-number tests", () => {
       expect(res.statusCode).toBe(400);
       expect($("h2.govuk-error-summary__title").text()).toContain("There is a problem");
       expect($('a[href="#herdCph"]').text()).toContain(
-        "Enter the CPH for this site, format should be nn/nnn/nnnn",
+        "Enter the CPH for this site in the format 12/345/6789",
       );
       expect($('p[id="herdCph-error"]').text()).toContain(
-        "Enter the CPH for this site, format should be nn/nnn/nnnn",
+        "Enter the CPH for this site in the format 12/345/6789",
       );
       expectSiteText($);
       expect($(".govuk-back-link").attr("href")).toContain("/select-site");


### PR DESCRIPTION
## Summary
Restore the agreed error wording on the Poultry "Enter CPH" screen. The previous content fix landed correctly, but a subsequent validation-scoping change reverted the on-screen copy back to the old wording. This change puts it back to what the design walkthrough specified, without touching the underlying validation logic.

## What Changed
- Updated the empty-field and bad-format error message to "Enter the CPH for this site in the format 12/345/6789"
- Updated the uniqueness-failure error message to "Enter a CPH that you have not used for a different site"
- Aligned the integration test assertions for the four affected error states

## Why
The on-screen copy had drifted from the spec, producing a regression visible to farmers entering a CPH on the Poultry claim flow. No validation behaviour changes - users see the same outcomes for the same inputs, only the wording is corrected.

## Screenshots
<img width="895" height="652" alt="Screenshot 2026-06-01 at 12 16 07" src="https://github.com/user-attachments/assets/786bc121-120b-4f90-b3c5-212890527b54" />
<img width="895" height="655" alt="Screenshot 2026-06-01 at 12 18 17" src="https://github.com/user-attachments/assets/2ea1e71c-fbad-467c-b05c-5f8f52d2e0c6" />
