### PR TITLE
fix(claims): (AHWR-1867) align poultry vet's name error message with regex #patch

### DIFF
--- a/app/routes/poultry/claim/vet-name.js
+++ b/app/routes/poultry/claim/vet-name.js
@@ -9,6 +9,11 @@ import {
 import { poultryClaimRoutes, poultryClaimViews } from "../../../constants/routes.js";
 import { vetsNameSchema } from "../../utils/schemas.js";
 
+const poultryVetsNameSchema = vetsNameSchema.messages({
+  "string.pattern.base":
+    "The vet's name must only include letters a to z, numbers and special characters such as hyphens, spaces, apostrophes, ampersands, commas, parentheses or a forward slash",
+});
+
 const getHandler = {
   method: "GET",
   path: poultryClaimRoutes.vetName,
@@ -33,7 +38,7 @@ const postHandler = {
   options: {
     validate: {
       payload: Joi.object({
-        vetsName: vetsNameSchema,
+        vetsName: poultryVetsNameSchema,
       }),
       failAction: async (request, h, error) => {
         request.logger.error({ error });

--- a/test/integration/narrow/routes/poultry/claim/vet-name.test.js
+++ b/test/integration/narrow/routes/poultry/claim/vet-name.test.js
@@ -16,7 +16,7 @@ const errorMessages = {
   enterName: "Enter the vet's name",
   nameLength: "The vet's name must be 50 characters or less",
   namePattern:
-    "The vet's name must only include letters a to z, numbers and special characters such as hyphens, spaces, apostrophes, ampersands, commas, brackets or a forward slash",
+    "The vet's name must only include letters a to z, numbers and special characters such as hyphens, spaces, apostrophes, ampersands, commas, parentheses or a forward slash",
 };
 
 jest.mock("../../../../../../app/session/index.js");


### PR DESCRIPTION
## Summary
The error message shown on the Poultry "vet's name" screen was misleading: it said "brackets" but the underlying regex only accepts parentheses. This PR aligns the Poultry message wording with the validation that is actually applied, leaving the Livestock equivalent untouched.

## What Changed
- Forked the Poultry pattern-failure message at the route call site via Joi `.messages()` override; the shared schema is unchanged.
- Replaced "brackets" with "parentheses" in the Poultry message wording.
- Updated the Poultry vet's name integration test to assert the new message.
- Livestock route, shared schema (regex, length, other messages) and Livestock tests are untouched.

## Why
"Brackets" is ambiguous in English - it could mean `[]`, `{}`, or `<>` - none of which the validator actually accepts. "Parentheses" is unambiguous and accurate. The fix is scoped to Poultry deliberately: the Livestock journey is in production and changing its copy is out of scope for this work, so the message is forked rather than the shared schema edited.

## Screenshot
<img width="891" height="731" alt="Screenshot 2026-06-03 at 09 24 08" src="https://github.com/user-attachments/assets/24127780-5d34-4897-b177-29356d494b6e" />
