### PR TITLE
fix: (AHWR-1979) exclude node timer and performance globals from global-jsdom #patch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@ministryofjustice/frontend": "5.2.1",
         "aws-embedded-metrics": "4.2.0",
         "ffc-ahwr-common-library": "3.8.2",
-        "form-data": "4.0.4",
+        "form-data": "4.0.6",
         "global-agent": "3.0.0",
         "govuk-frontend": "5.14.0",
         "hapi-pino": "12.1.0",
@@ -9169,14 +9169,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -9662,7 +9664,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@ministryofjustice/frontend": "5.2.1",
     "aws-embedded-metrics": "4.2.0",
     "ffc-ahwr-common-library": "3.8.2",
-    "form-data": "4.0.4",
+    "form-data": "4.0.6",
     "global-agent": "3.0.0",
     "govuk-frontend": "5.14.0",
     "hapi-pino": "12.1.0",

--- a/patches/global-jsdom+26.0.0.patch
+++ b/patches/global-jsdom+26.0.0.patch
@@ -1,0 +1,54 @@
+diff --git a/node_modules/global-jsdom/commonjs/index.cjs b/node_modules/global-jsdom/commonjs/index.cjs
+index 6a52a40..f5478b0 100644
+--- a/node_modules/global-jsdom/commonjs/index.cjs
++++ b/node_modules/global-jsdom/commonjs/index.cjs
+@@ -9,6 +9,13 @@ const defaultHtml = '<!doctype html><html><head><meta charset="utf-8"></head><bo
+ 
+ const KEYS = []
+ 
++// Node provides these as global accessors that `(k in global)` cannot detect (notably in jest's
++// node test environment), so without this they wrongly get copied from the jsdom window on setup
++// and deleted on cleanup. jsdom 26 relies on the real Node timers/performance (e.g. Window.js calls
++// the global setTimeout to schedule timers and performance.now() while building the Window), so
++// they must be left untouched.
++const NODE_GLOBALS = new Set(['performance', 'setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'setImmediate', 'clearImmediate', 'queueMicrotask'])
++
+ module.exports = function globalJsdom(html = defaultHtml, options = {}) {
+   // Idempotency
+   if (global.navigator
+@@ -35,7 +42,7 @@ module.exports = function globalJsdom(html = defaultHtml, options = {}) {
+   // that node already defines
+ 
+   if (KEYS.length === 0) {
+-    KEYS.push(...Object.getOwnPropertyNames(window).filter((k) => !k.startsWith('_') && !(k in global)))
++    KEYS.push(...Object.getOwnPropertyNames(window).filter((k) => !k.startsWith('_') && !(k in global) && !NODE_GLOBALS.has(k)))
+     // going to add our jsdom instance, see below
+     KEYS.push('$jsdom')
+   }
+diff --git a/node_modules/global-jsdom/esm/index.mjs b/node_modules/global-jsdom/esm/index.mjs
+index 6bd8ab4..c57486a 100644
+--- a/node_modules/global-jsdom/esm/index.mjs
++++ b/node_modules/global-jsdom/esm/index.mjs
+@@ -9,6 +9,13 @@ const defaultHtml = '<!doctype html><html><head><meta charset="utf-8"></head><bo
+ 
+ const KEYS = []
+ 
++// Node provides these as global accessors that `(k in global)` cannot detect (notably in jest's
++// node test environment), so without this they wrongly get copied from the jsdom window on setup
++// and deleted on cleanup. jsdom 26 relies on the real Node timers/performance (e.g. Window.js calls
++// the global setTimeout to schedule timers and performance.now() while building the Window), so
++// they must be left untouched.
++const NODE_GLOBALS = new Set(['performance', 'setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'setImmediate', 'clearImmediate', 'queueMicrotask'])
++
+ export default function globalJsdom(html = defaultHtml, options = {}) {
+   // Idempotency
+   if (global.navigator
+@@ -35,7 +42,7 @@ export default function globalJsdom(html = defaultHtml, options = {}) {
+   // that node already defines
+ 
+   if (KEYS.length === 0) {
+-    KEYS.push(...Object.getOwnPropertyNames(window).filter((k) => !k.startsWith('_') && !(k in global)))
++    KEYS.push(...Object.getOwnPropertyNames(window).filter((k) => !k.startsWith('_') && !(k in global) && !NODE_GLOBALS.has(k)))
+     // going to add our jsdom instance, see below
+     KEYS.push('$jsdom')
+   }

--- a/test/integration/narrow/routes/global-jsdom-reuse.test.js
+++ b/test/integration/narrow/routes/global-jsdom-reuse.test.js
@@ -1,0 +1,44 @@
+/**
+ * @jest-environment node
+ */
+import globalJsdom from "global-jsdom";
+
+describe("global-jsdom reuse after cleanup", () => {
+  let cleanup;
+
+  afterEach(() => {
+    if (cleanup) {
+      cleanup();
+      cleanup = undefined;
+    }
+  });
+
+  test("leaves Node performance and timer globals defined after cleanup", () => {
+    const teardown = globalJsdom("<p>first</p>");
+
+    teardown();
+
+    expect(performance).toBeDefined();
+    expect(setTimeout).toBeDefined();
+    expect(clearTimeout).toBeDefined();
+    expect(setInterval).toBeDefined();
+    expect(clearInterval).toBeDefined();
+  });
+
+  test("renders a second document when globalJsdom is reused after cleanup", () => {
+    const firstTeardown = globalJsdom("<p>first</p>");
+    firstTeardown();
+
+    cleanup = globalJsdom('<p id="marker">second</p>');
+
+    expect(document.getElementById("marker").textContent).toBe("second");
+  });
+
+  test("leaves the real Node setTimeout in place so timers still fire after setup", async () => {
+    cleanup = globalJsdom("<p>first</p>");
+
+    await expect(new Promise((resolve) => setTimeout(() => resolve("fired"), 0))).resolves.toBe(
+      "fired",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Unblocks the CI pipeline for the public UI, which was failing on two fronts: the integration test suite (global-jsdom mismanaging Node's performance/timer globals under Jest's node environment) and the security audit gate (a high-severity form-data advisory).

Both are addressed so the pipeline goes green.

## What Changed
- Add a patch-package patch on global-jsdom (commonjs and esm builds) that stops it claiming Node's timer/performance globals, so they are no longer overwritten on setup or deleted on cleanup.
- Add a Jest regression test covering reuse-after-cleanup and timers firing after setup.
- Bump form-data to 4.0.6 to resolve the high-severity CRLF advisory (GHSA-hmw2-7cc7-3qxx) that was failing the audit gate.

## Why
The two test suites had been broken since they were added against the v26 jsdom stack; leaving Node's built-ins off global-jsdom's managed list resolves both failure modes at source. The form-data advisory was an unrelated pre-existing production-dependency issue surfacing on the audit gate; 4.0.6 is the only available fix. Both changes are required to get a clean CI run.