### PR TITLE
refactor(templates): (AHWR-1978) rename beforeContent overrides to containerStart #patch

### DIFF
--- a/app/views/apply/declaration.njk
+++ b/app/views/apply/declaration.njk
@@ -3,7 +3,7 @@
 
 {% block pageTitle %}{% if errorMessage %}Error: {% endif %}Review your agreement offer - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/apply/numbers.njk
+++ b/app/views/apply/numbers.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}Minimum number of each species in each herd or flock - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
 {{ govukBackLink({
 text: "Back",
 href: backLink,

--- a/app/views/apply/timings.njk
+++ b/app/views/apply/timings.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}Timing of reviews and follow-ups - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/apply/you-can-claim-multiple.njk
+++ b/app/views/apply/you-can-claim-multiple.njk
@@ -4,7 +4,7 @@
 
 {% block pageTitle %}{{ pageHeadingText }} - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
 {{ govukBackLink({
 text: "Back",
 href: backLink,

--- a/app/views/check-details.njk
+++ b/app/views/check-details.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}{% if errorMessage %}Error: {% endif %}Check your details - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink.href,

--- a/app/views/claim/assurance-scheme.njk
+++ b/app/views/claim/assurance-scheme.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}{% if errorMessage %}Error: {% endif %}Did the vet do a biosecurity assessment? - {{ serviceName }} - GOV.UK{% endblock %}
 
-{%block beforeContent %}
+{% block containerStart %}
   {{ 
     govukBackLink({
       text: "Back",

--- a/app/views/claim/biosecurity-exception.njk
+++ b/app/views/claim/biosecurity-exception.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}You cannot continue with your claim - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/claim/biosecurity.njk
+++ b/app/views/claim/biosecurity.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}{% if errorMessage %}Error: {% endif %}Did the vet do a biosecurity assessment? - {{ serviceName }} - GOV.UK{% endblock %}
 
-{%block beforeContent %}
+{% block containerStart %}
   {{ 
     govukBackLink({
       text: "Back",

--- a/app/views/claim/check-answers.njk
+++ b/app/views/claim/check-answers.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}Check your answers - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/claim/check-herd-details.njk
+++ b/app/views/claim/check-herd-details.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}Check {{ herdOrFlock }} details - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/claim/dairy-follow-up-date-exception.njk
+++ b/app/views/claim/dairy-follow-up-date-exception.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}You cannot continue with your claim - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/claim/date-of-testing-exception.njk
+++ b/app/views/claim/date-of-testing-exception.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}You cannot continue with your claim - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/claim/date-of-testing.njk
+++ b/app/views/claim/date-of-testing.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}{% if errorSummary.length %}Error: {% endif %}When were samples taken? - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/claim/date-of-visit-exception.njk
+++ b/app/views/claim/date-of-visit-exception.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}You cannot continue with your claim - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/claim/date-of-visit.njk
+++ b/app/views/claim/date-of-visit.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}{% if errorSummary.length %}Error: {% endif %}Date of {{ reviewOrFollowUpText }} - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/claim/dev-sign-in.njk
+++ b/app/views/claim/dev-sign-in.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}{% if errorMessage %}Error: {% endif %}What is your SBI? - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href:backLink,

--- a/app/views/claim/disease-status.njk
+++ b/app/views/claim/disease-status.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}{% if errorMessage %}Error: {% endif %}What is the disease status category? - {{ serviceName }} - GOV.UK{% endblock %}
 
-{%block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink

--- a/app/views/claim/enter-cph-number.njk
+++ b/app/views/claim/enter-cph-number.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}{% if errorMessage %}Error: {% endif %}Enter the CPH number for this {{ herdOrFlock }} - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/claim/enter-herd-details.njk
+++ b/app/views/claim/enter-herd-details.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}{% if errorMessage %}Error: {% endif %}Enter the {{ herdOrFlock }} details - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/claim/enter-herd-name.njk
+++ b/app/views/claim/enter-herd-name.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}{% if errorMessage %}Error: {% endif %}Enter the {{ herdOrFlock }} name - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/claim/herd-others-on-sbi.njk
+++ b/app/views/claim/herd-others-on-sbi.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}{% if errorMessage %}Error: {% endif %}Is this the only {{ speciesGroupText }} associated with this Single Business Identifier (SBI)? - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/claim/multiple-species-date-exception.njk
+++ b/app/views/claim/multiple-species-date-exception.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}You cannot continue with your claim - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/claim/number-of-blood-samples-exception.njk
+++ b/app/views/claim/number-of-blood-samples-exception.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}Oral fluid samples exception - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/claim/number-of-blood-samples.njk
+++ b/app/views/claim/number-of-blood-samples.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}{% if errorMessage %}Error: {% endif %}How many blood samples were tested? - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/claim/number-of-fluid-oral-samples-exception.njk
+++ b/app/views/claim/number-of-fluid-oral-samples-exception.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}Oral fluid samples exception - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/claim/number-of-fluid-oral-samples.njk
+++ b/app/views/claim/number-of-fluid-oral-samples.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}{% if errorMessage %}Error: {% endif %}How many oral fluid samples were tested? - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/claim/number-of-samples-tested-exception.njk
+++ b/app/views/claim/number-of-samples-tested-exception.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}Samples tested exception - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/claim/number-of-samples-tested.njk
+++ b/app/views/claim/number-of-samples-tested.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}{% if errorMessage %}Error: {% endif %}How many samples were tested? - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/claim/number-of-species-exception.njk
+++ b/app/views/claim/number-of-species-exception.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}You cannot continue with your claim - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/claim/number-of-species-pigs-exception.njk
+++ b/app/views/claim/number-of-species-pigs-exception.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}You cannot continue with your claim - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/claim/number-of-species-sheep-exception.njk
+++ b/app/views/claim/number-of-species-sheep-exception.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}You cannot continue with your claim - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/claim/number-of-species-tested.njk
+++ b/app/views/claim/number-of-species-tested.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}{% if errorMessage %}Error: {% endif %}{{questionText}} - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href:backLink,

--- a/app/views/claim/pi-hunt-all-animals-exception.njk
+++ b/app/views/claim/pi-hunt-all-animals-exception.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}You cannot continue with your claim - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/claim/pi-hunt-all-animals.njk
+++ b/app/views/claim/pi-hunt-all-animals.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}{% if errorMessage %}Error: {% endif %}{{ title }} - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/claim/pi-hunt-exception.njk
+++ b/app/views/claim/pi-hunt-exception.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}You cannot continue with your claim - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/claim/pi-hunt-recommended-exception.njk
+++ b/app/views/claim/pi-hunt-recommended-exception.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}There could be a problem with your claim - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/claim/pi-hunt-recommended.njk
+++ b/app/views/claim/pi-hunt-recommended.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}{% if errorMessage %}Error: {% endif %}{{ title }} - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/claim/pi-hunt.njk
+++ b/app/views/claim/pi-hunt.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}{% if errorMessage %}Error: {% endif %}{{ titleText }} - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/claim/pigs-elisa-result.njk
+++ b/app/views/claim/pigs-elisa-result.njk
@@ -1,6 +1,6 @@
 {% extends './layouts/layout.njk' %} {% block pageTitle %}{% if errorMessage
     %}Error: {% endif %}What was the result of the ELISA test? - {{ serviceName }} - GOV.UK{% endblock %}
-    {%block beforeContent %}
+    {% block containerStart %}
     {{
       govukBackLink({
         text: "Back",

--- a/app/views/claim/pigs-genetic-sequencing.njk
+++ b/app/views/claim/pigs-genetic-sequencing.njk
@@ -1,6 +1,6 @@
 {% extends './layouts/layout.njk' %} {% block pageTitle %}{% if errorMessage
 %}Error: {% endif %}What was the result of the genetic sequencing? - {{ serviceName }} - GOV.UK{% endblock
-%} {%block beforeContent %}
+%} {% block containerStart %}
 {{
   govukBackLink({
     text: "Back",

--- a/app/views/claim/pigs-pcr-result.njk
+++ b/app/views/claim/pigs-pcr-result.njk
@@ -1,6 +1,6 @@
 {% extends './layouts/layout.njk' %} {% block pageTitle %}{% if errorMessage
   %}Error: {% endif %}What was the result of the PCR test? - {{ serviceName }} - GOV.UK{% endblock %}
-  {%block beforeContent %}
+  {% block containerStart %}
   {{
     govukBackLink({
       text: "Back",

--- a/app/views/claim/same-herd-exception.njk
+++ b/app/views/claim/same-herd-exception.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}You cannot continue with your claim - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/claim/same-herd.njk
+++ b/app/views/claim/same-herd.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}{% if errorMessage %}Error: {% endif %}Is this the same {{herdOrFlock}} you have previously claimed for? - {{serviceName}} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/claim/select-the-herd-date-exception.njk
+++ b/app/views/claim/select-the-herd-date-exception.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}You cannot continue with your claim - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/claim/select-the-herd-exception.njk
+++ b/app/views/claim/select-the-herd-exception.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}You cannot continue with your claim - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/claim/select-the-herd.njk
+++ b/app/views/claim/select-the-herd.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}{% if errorMessage %}Error: {% endif %}{{pageTitleText}} - {{serviceName}} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/claim/sheep-endemics-package.njk
+++ b/app/views/claim/sheep-endemics-package.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}{% if errorMessage %}Error: {% endif %}{{ pageHeading }} - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/claim/sheep-test-results.njk
+++ b/app/views/claim/sheep-test-results.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}{% if errorList | length %}Error: {% endif %}{{ pageTitle }} - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
         text: "Back",
         href: backLink

--- a/app/views/claim/sheep-tests.njk
+++ b/app/views/claim/sheep-tests.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}{% if errorMessage %}Error: {% endif %}Which disease or condition did the vet take samples to test for? - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
       text: "Back",
       href: backLink

--- a/app/views/claim/species-numbers-exception.njk
+++ b/app/views/claim/species-numbers-exception.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}You cannot continue with your claim - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/claim/species-numbers.njk
+++ b/app/views/claim/species-numbers.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}{% if errorMessage %}Error: {% endif %}{{ customisedTitle }} - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/claim/test-results.njk
+++ b/app/views/claim/test-results.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}{% if errorMessage %}Error: {% endif %}{{ title }} - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/claim/test-urn-exception.njk
+++ b/app/views/claim/test-urn-exception.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}You cannot continue with your claim - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/claim/test-urn.njk
+++ b/app/views/claim/test-urn.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}{% if errorMessage %}Error: {% endif %}{{ title }} - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/claim/type-of-samples-taken.njk
+++ b/app/views/claim/type-of-samples-taken.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}{% if errorMessage %}Error: {% endif %}What type of samples were taken? - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/claim/vaccination.njk
+++ b/app/views/claim/vaccination.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}{% if errorMessage %}Error: {% endif %}Herd Vaccination Status - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/claim/vet-name.njk
+++ b/app/views/claim/vet-name.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}{% if errorMessage %}Error: {% endif %}What is the vet's name? - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href:backLink,

--- a/app/views/claim/vet-rcvs.njk
+++ b/app/views/claim/vet-rcvs.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}{% if errorMessage %}Error: {% endif %}What is the vet's Royal College of Veterinary Surgeons (RCVS) number? - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/claim/vet-visits-review-test-results.njk
+++ b/app/views/claim/vet-visits-review-test-results.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}{% if errorMessage %}Error: {% endif %}Vet Visits Review Test Results - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/claim/which-species-poultry.njk
+++ b/app/views/claim/which-species-poultry.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}{% if errorMessage %}Error: {% endif %}Which species are you claiming for? - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
         text: "Back",
         href: backLink

--- a/app/views/claim/which-species.njk
+++ b/app/views/claim/which-species.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}{% if errorMessage %}Error: {% endif %}Which species are you claiming for? - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
         text: "Back",
         href: backLink

--- a/app/views/claim/which-type-of-review-dairy-follow-up-exception.njk
+++ b/app/views/claim/which-type-of-review-dairy-follow-up-exception.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}Which type of review dairy follow up exception - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/claim/which-type-of-review-exception.njk
+++ b/app/views/claim/which-type-of-review-exception.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}You cannot continue with your claim - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/claim/which-type-of-review.njk
+++ b/app/views/claim/which-type-of-review.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}{% if errorMessage %}Error: {% endif %}Are you claiming for a review or follow-up? - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
         text: "Back",
         href: backLink

--- a/app/views/claim/you-cannot-claim.njk
+++ b/app/views/claim/you-cannot-claim.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %} You cannot claim  - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
         text: "Back",
         href: backLink

--- a/app/views/dashboard.njk
+++ b/app/views/dashboard.njk
@@ -5,7 +5,7 @@
   AHWR Dashboard
 {% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
         text: "Back",
         href: "/"

--- a/app/views/poultry/apply/declaration.njk
+++ b/app/views/poultry/apply/declaration.njk
@@ -3,7 +3,7 @@
 
 {% block pageTitle %}{% if errorMessage %}Error: {% endif %}Review your agreement offer - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/poultry/apply/numbers.njk
+++ b/app/views/poultry/apply/numbers.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}Minimum number of poultry on the site - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
 {{ govukBackLink({
 text: "Back",
 href: backLink,

--- a/app/views/poultry/apply/terms-rejected.njk
+++ b/app/views/poultry/apply/terms-rejected.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}You cannot continue with your application - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
 {{ govukBackLink({
 text: "Back",
 href: backLink,

--- a/app/views/poultry/apply/timings.njk
+++ b/app/views/poultry/apply/timings.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}Timing of poultry biosecurity reviews - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/poultry/apply/you-can-claim-multiple.njk
+++ b/app/views/poultry/apply/you-can-claim-multiple.njk
@@ -4,7 +4,7 @@
 
 {% block pageTitle %}{{ pageHeadingText }} - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
 {{ govukBackLink({
 text: "Back",
 href: backLink,

--- a/app/views/poultry/claim/biosecurity-cost-of-changes.njk
+++ b/app/views/poultry/claim/biosecurity-cost-of-changes.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}{% if errorMessage %}Error: {% endif %}How much do you expect to spend on recommended biosecurity changes? - {{ serviceName }} - GOV.UK{% endblock %}
 
-{%block beforeContent %}
+{% block containerStart %}
   {{ 
     govukBackLink({
       text: "Back",

--- a/app/views/poultry/claim/biosecurity-exception.njk
+++ b/app/views/poultry/claim/biosecurity-exception.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}You cannot continue with your claim - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/poultry/claim/biosecurity-usefulness.njk
+++ b/app/views/poultry/claim/biosecurity-usefulness.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}{% if errorMessage %}Error: {% endif %}How useful was the vet's advice for improving your farm's biosecurity? - {{ serviceName }} - GOV.UK{% endblock %}
 
-{%block beforeContent %}
+{% block containerStart %}
   {{ 
     govukBackLink({
       text: "Back",

--- a/app/views/poultry/claim/biosecurity.njk
+++ b/app/views/poultry/claim/biosecurity.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}{% if errorMessage %}Error: {% endif %}Did the vet do a biosecurity assessment? - {{ serviceName }} - GOV.UK{% endblock %}
 
-{%block beforeContent %}
+{% block containerStart %}
   {{ 
     govukBackLink({
       text: "Back",

--- a/app/views/poultry/claim/cannot-continue-timing-rules.njk
+++ b/app/views/poultry/claim/cannot-continue-timing-rules.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}You cannot continue with your claim - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/poultry/claim/changes-in-biosecurity.njk
+++ b/app/views/poultry/claim/changes-in-biosecurity.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}{% if errorMessage %}Error: {% endif %}Which recommendation did the vet say should be your top priority? - {{ serviceName }} - GOV.UK{% endblock %}
 
-{%block beforeContent %}
+{% block containerStart %}
   {{ 
     govukBackLink({
       text: "Back",

--- a/app/views/poultry/claim/check-answers.njk
+++ b/app/views/poultry/claim/check-answers.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}Check your answers - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/poultry/claim/date-of-visit.njk
+++ b/app/views/poultry/claim/date-of-visit.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}{% if errorSummary.length %}Error: {% endif %}Date of visit - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/poultry/claim/enter-cph-number.njk
+++ b/app/views/poultry/claim/enter-cph-number.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}{% if errorMessage %}Error: {% endif %}Enter the CPH number for this site - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/poultry/claim/enter-site-name.njk
+++ b/app/views/poultry/claim/enter-site-name.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}{% if errorMessage %}Error: {% endif %}Enter the site name - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/poultry/claim/interview.njk
+++ b/app/views/poultry/claim/interview.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}{% if errorMessage %}Error: {% endif %}Would you be willing to take part in a short follow-up interview about your experience of this scheme? - {{ serviceName }} - GOV.UK{% endblock %}
 
-{%block beforeContent %}
+{% block containerStart %}
   {{ 
     govukBackLink({
       text: "Back",

--- a/app/views/poultry/claim/minimum-number-of-birds-exception.njk
+++ b/app/views/poultry/claim/minimum-number-of-birds-exception.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}You cannot continue with your claim - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/poultry/claim/minimum-number-of-birds.njk
+++ b/app/views/poultry/claim/minimum-number-of-birds.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}{% if errorMessage %}Error: {% endif %}Minimum number of birds - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/poultry/claim/select-poultry-type.njk
+++ b/app/views/poultry/claim/select-poultry-type.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}{% if errorMessage %}Error: {% endif %}Select poultry type - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/poultry/claim/select-the-site.njk
+++ b/app/views/poultry/claim/select-the-site.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}{% if errorMessage %}Error: {% endif %}{{pageTitleText}} - {{serviceName}} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/poultry/claim/site-others-on-sbi.njk
+++ b/app/views/poultry/claim/site-others-on-sbi.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}{% if errorMessage %}Error: {% endif %}Is this the only site associated with this Single Business Identifier (SBI)? - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/poultry/claim/vet-name.njk
+++ b/app/views/poultry/claim/vet-name.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}{% if errorMessage %}Error: {% endif %}What is the vet's name? - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href:backLink,

--- a/app/views/poultry/claim/vet-rcvs.njk
+++ b/app/views/poultry/claim/vet-rcvs.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}{% if errorMessage %}Error: {% endif %}What is the vet's Royal College of Veterinary Surgeons (RCVS) number? - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,

--- a/app/views/update-details.njk
+++ b/app/views/update-details.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}Update your details - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: "/check-details",

--- a/app/views/verify-login-failed.njk
+++ b/app/views/verify-login-failed.njk
@@ -2,7 +2,7 @@
 
 {% block pageTitle %}Login failed - {{ serviceName }} - GOV.UK{% endblock %}
 
-{% block beforeContent %}
+{% block containerStart %}
   {{ govukBackLink({
     text: "Back",
     href: backLink,


### PR DESCRIPTION
## Summary
Renames the deprecated `beforeContent` Nunjucks block override to `containerStart` across all 91 public-UI templates that override it. This is the deferred forward-proofing follow-up to the GOV.UK Frontend v6 upgrade. It is a purely mechanical rename with no content, layout, behaviour, or visual change.

## What Changed
- Renamed `{% block beforeContent %}` to `{% block containerStart %}` in 91 templates under `app/views`.
- Normalised 11 templates that used the non-standard no-space form (`{%block beforeContent %}`) to the canonical spacing while renaming.
- Diff is exactly +91/-91: one single-token swap per file. No closing tags, no JavaScript, and no non-template files touched.

## Why
In v6 the base template nests `beforeContent` inside the new `containerStart` block as its default content, so the existing overrides keep working on v6 with no warning - but they depend on a back-compat shim that a future GOV.UK major could remove. Overriding `containerStart` directly renders at the identical position and removes that dependency. Completeness was verified by a grep gate (zero remaining `beforeContent` overrides, 91 `containerStart` blocks) rather than the test suite, because the shim keeps any missed override rendering green.