### PR TITLE
fix: (AHWR-1992) build production frontend bundle in production mode #patch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY --chown=node:node package*.json ./
 RUN npm install --ignore-scripts
 COPY --chown=node:node . .
 RUN npx patch-package
-RUN npm run build
+RUN NODE_ENV=production npm run build
 CMD [ "npm", "run", "start:watch" ]
 
 # Production


### PR DESCRIPTION
## Summary
The production Docker image served a development-mode webpack bundle to browsers in every environment. The bundle was eval-wrapped, unminified, and shipped with public source maps. This compiles the frontend in production mode for the production image instead.

## What Changed
- The frontend build step in the Dockerfile's development stage now runs in production mode, so the bundle copied into the production image is minified, eval-free, and has no source maps.

## Why
- Cuts the JavaScript payload sent to every farmer by roughly 3.5x (~593 KiB down to ~171 KiB).
- Stops publishing source maps publicly; no client-side tooling consumes them.
- Removes eval-based execution, which unblocks hardening the Content Security Policy (the follow-up work to drop 'unsafe-eval', which must only be enforced once this is deployed).
- Local development is unaffected: the override scopes only to the build step, and watch-mode still rebuilds in development mode at runtime.