### PR TITLE
chore: AHWR-2034 disable Redis ready check #patch

### DIFF
--- a/app/cache/build-redis-client.js
+++ b/app/cache/build-redis-client.js
@@ -31,6 +31,7 @@ export function buildRedisClient() {
       host,
       db,
       keyPrefix,
+      enableReadyCheck: false,
       ...credentials,
       ...tls,
     });

--- a/test/unit/app/cache/build-redis-client.test.js
+++ b/test/unit/app/cache/build-redis-client.test.js
@@ -44,6 +44,7 @@ describe("buildRedisClient", () => {
       host: "test-host",
       db: 0,
       keyPrefix: "test-keyprefix",
+      enableReadyCheck: false,
     });
 
     expect(Cluster).not.toHaveBeenCalled();


### PR DESCRIPTION
Disable Redis `enableReadyCheck` as it is skipped anyway and creates noise in the logs