### PR TITLE
feat(livestock): (AHWR-1955) differentiate livestock screen titles from poultry

### DIFF
--- a/app/routes/livestock/claim/select-the-herd.js
+++ b/app/routes/livestock/claim/select-the-herd.js
@@ -40,6 +40,18 @@ const createUnnamedHerd = (claim, typeOfLivestock) => ({
   name: `Unnamed ${getHerdOrFlock(typeOfLivestock)} (Last claim: ${claim.type === claimType.review ? "review" : "follow-up"} visit on the ${formatDate(claim.data.dateOfVisit)})`,
 });
 
+const getSelectHerdTitles = (herds, herdOrFlock) => {
+  const multipleHerds = herds.length > 1;
+  return {
+    pageTitleText: multipleHerds
+      ? `Select the ${herdOrFlock} you are claiming for`
+      : `Is this the same ${herdOrFlock} you have previously claimed for?`,
+    browserTitle: multipleHerds
+      ? `Livestock ${herdOrFlock} you are claiming for`
+      : `Is this the same livestock ${herdOrFlock} you have previously claimed for?`,
+  };
+};
+
 const getHandler = {
   method: "GET",
   path: pageUrl,
@@ -57,10 +69,7 @@ const getHandler = {
 
       return h.view(claimViews.selectTheHerd, {
         backLink: claimRoutes.dateOfVisit,
-        pageTitleText:
-          herds.length > 1
-            ? `Select the ${herdOrFlock} you are claiming for`
-            : `Is this the same ${herdOrFlock} you have previously claimed for?`,
+        ...getSelectHerdTitles(herds, herdOrFlock),
         radioValueNewHerd,
         ...claimInfo,
         herds: claimWithoutHerd
@@ -162,10 +171,7 @@ const postHandler = {
               href: "#herdSelected",
             },
             backLink: claimRoutes.dateOfVisit,
-            pageTitleText:
-              herds.length > 1
-                ? `Select the ${herdOrFlock} you are claiming for`
-                : `Is this the same ${herdOrFlock} you have previously claimed for?`,
+            ...getSelectHerdTitles(herds, herdOrFlock),
             radioValueNewHerd,
             ...claimInfo,
             herds: claimWithoutHerd

--- a/app/routes/livestock/claim/species-numbers.js
+++ b/app/routes/livestock/claim/species-numbers.js
@@ -130,9 +130,12 @@ const getHandler = {
         claim.latestEndemicsApplication,
       );
 
+      const { isReview } = getReviewType(claim.typeOfReview);
+      const reviewOrFollowUp = isReview ? "review" : "follow-up";
+
       return h.view(claimViews.speciesNumbers, {
         backLink: backLink(request),
-        customisedTitle: questionText,
+        customisedTitle: `Minimum number of livestock on date of ${reviewOrFollowUp}?`,
         ...getYesNoRadios(
           questionText,
           sessionKeys.endemicsClaim.speciesNumbers,

--- a/app/views/livestock/apply/confirmation.njk
+++ b/app/views/livestock/apply/confirmation.njk
@@ -1,6 +1,6 @@
 {% extends './layouts/layout.njk' %}
 
-{% block pageTitle %}Application complete - {{ serviceName }} - GOV.UK{% endblock %}
+{% block pageTitle %}Livestock application complete - {{ serviceName }} - GOV.UK{% endblock %}
 
 {% block content %}
   <div class="govuk-grid-row">

--- a/app/views/livestock/apply/declaration.njk
+++ b/app/views/livestock/apply/declaration.njk
@@ -1,7 +1,7 @@
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% extends './layouts/layout.njk' %}
 
-{% block pageTitle %}{% if errorMessage %}Error: {% endif %}Review your agreement offer - {{ serviceName }} - GOV.UK{% endblock %}
+{% block pageTitle %}{% if errorMessage %}Error: {% endif %}Review your livestock agreement offer - {{ serviceName }} - GOV.UK{% endblock %}
 
 {% block containerStart %}
   {{ govukBackLink({

--- a/app/views/livestock/apply/numbers.njk
+++ b/app/views/livestock/apply/numbers.njk
@@ -1,6 +1,6 @@
 {% extends './layouts/layout.njk' %}
 
-{% block pageTitle %}Minimum number of each species in each herd or flock - {{ serviceName }} - GOV.UK{% endblock %}
+{% block pageTitle %}Minimum number of livestock - {{ serviceName }} - GOV.UK{% endblock %}
 
 {% block containerStart %}
 {{ govukBackLink({

--- a/app/views/livestock/apply/offer-rejected.njk
+++ b/app/views/livestock/apply/offer-rejected.njk
@@ -4,7 +4,7 @@
 {% if termsRejected %}
   You cannot continue with your application - {{ serviceName }} - GOV.UK
 {% elif offerRejected %}
-  Agreement offer rejected - {{ serviceName }} - GOV.UK
+  Livestock agreement offer rejected - {{ serviceName }} - GOV.UK
 {% endif %}
 {% endblock %}
 

--- a/app/views/livestock/apply/timings.njk
+++ b/app/views/livestock/apply/timings.njk
@@ -1,6 +1,6 @@
 {% extends './layouts/layout.njk' %}
 
-{% block pageTitle %}Timing of reviews and follow-ups - {{ serviceName }} - GOV.UK{% endblock %}
+{% block pageTitle %}Timing of livestock reviews and follow-ups - {{ serviceName }} - GOV.UK{% endblock %}
 
 {% block containerStart %}
   {{ govukBackLink({

--- a/app/views/livestock/apply/you-can-claim-multiple.njk
+++ b/app/views/livestock/apply/you-can-claim-multiple.njk
@@ -2,7 +2,7 @@
 
 {% set pageHeadingText='What you can claim for as part of this agreement' %}
 
-{% block pageTitle %}{{ pageHeadingText }} - {{ serviceName }} - GOV.UK{% endblock %}
+{% block pageTitle %}What you can claim for a livestock agreement - {{ serviceName }} - GOV.UK{% endblock %}
 
 {% block containerStart %}
 {{ govukBackLink({

--- a/app/views/livestock/claim/assurance-scheme.njk
+++ b/app/views/livestock/claim/assurance-scheme.njk
@@ -1,6 +1,6 @@
 {% extends './layouts/layout.njk' %}
 
-{% block pageTitle %}{% if errorMessage %}Error: {% endif %}Did the vet do a biosecurity assessment? - {{ serviceName }} - GOV.UK{% endblock %}
+{% block pageTitle %}{% if errorMessage %}Error: {% endif %}Livestock biosecurity assessment - {{ serviceName }} - GOV.UK{% endblock %}
 
 {% block containerStart %}
   {{ 

--- a/app/views/livestock/claim/biosecurity.njk
+++ b/app/views/livestock/claim/biosecurity.njk
@@ -1,6 +1,6 @@
 {% extends './layouts/layout.njk' %}
 
-{% block pageTitle %}{% if errorMessage %}Error: {% endif %}Did the vet do a biosecurity assessment? - {{ serviceName }} - GOV.UK{% endblock %}
+{% block pageTitle %}{% if errorMessage %}Error: {% endif %}Livestock biosecurity assessment - {{ serviceName }} - GOV.UK{% endblock %}
 
 {% block containerStart %}
   {{ 

--- a/app/views/livestock/claim/check-answers.njk
+++ b/app/views/livestock/claim/check-answers.njk
@@ -1,6 +1,6 @@
 {% extends './layouts/layout.njk' %}
 
-{% block pageTitle %}Check your answers - {{ serviceName }} - GOV.UK{% endblock %}
+{% block pageTitle %}Check your answers before submitting your livestock claim - {{ serviceName }} - GOV.UK{% endblock %}
 
 {% block containerStart %}
   {{ govukBackLink({

--- a/app/views/livestock/claim/check-herd-details.njk
+++ b/app/views/livestock/claim/check-herd-details.njk
@@ -1,6 +1,6 @@
 {% extends './layouts/layout.njk' %}
 
-{% block pageTitle %}Check {{ herdOrFlock }} details - {{ serviceName }} - GOV.UK{% endblock %}
+{% block pageTitle %}Check livestock {{ herdOrFlock }} details - {{ serviceName }} - GOV.UK{% endblock %}
 
 {% block containerStart %}
   {{ govukBackLink({

--- a/app/views/livestock/claim/confirmation.njk
+++ b/app/views/livestock/claim/confirmation.njk
@@ -1,6 +1,6 @@
 {% extends './layouts/layout.njk' %}
 
-{% block pageTitle %}Claim complete - {{ serviceName }} - GOV.UK{% endblock %}
+{% block pageTitle %}Livestock claim submitted - {{ serviceName }} - GOV.UK{% endblock %}
 
 {% block content %}
   <div class="govuk-grid-row">

--- a/app/views/livestock/claim/date-of-testing.njk
+++ b/app/views/livestock/claim/date-of-testing.njk
@@ -1,6 +1,6 @@
 {% extends './layouts/layout.njk' %}
 
-{% block pageTitle %}{% if errorSummary.length %}Error: {% endif %}When were samples taken? - {{ serviceName }} - GOV.UK{% endblock %}
+{% block pageTitle %}{% if errorSummary.length %}Error: {% endif %}When livestock samples were taken - {{ serviceName }} - GOV.UK{% endblock %}
 
 {% block containerStart %}
   {{ govukBackLink({

--- a/app/views/livestock/claim/date-of-visit.njk
+++ b/app/views/livestock/claim/date-of-visit.njk
@@ -1,6 +1,6 @@
 {% extends './layouts/layout.njk' %}
 
-{% block pageTitle %}{% if errorSummary.length %}Error: {% endif %}Date of {{ reviewOrFollowUpText }} - {{ serviceName }} - GOV.UK{% endblock %}
+{% block pageTitle %}{% if errorSummary.length %}Error: {% endif %}Date of livestock {{ reviewOrFollowUpText }} - {{ serviceName }} - GOV.UK{% endblock %}
 
 {% block containerStart %}
   {{ govukBackLink({

--- a/app/views/livestock/claim/disease-status.njk
+++ b/app/views/livestock/claim/disease-status.njk
@@ -1,6 +1,6 @@
 {% extends './layouts/layout.njk' %}
 
-{% block pageTitle %}{% if errorMessage %}Error: {% endif %}What is the disease status category? - {{ serviceName }} - GOV.UK{% endblock %}
+{% block pageTitle %}{% if errorMessage %}Error: {% endif %}Livestock disease status - {{ serviceName }} - GOV.UK{% endblock %}
 
 {% block containerStart %}
   {{ govukBackLink({

--- a/app/views/livestock/claim/enter-cph-number.njk
+++ b/app/views/livestock/claim/enter-cph-number.njk
@@ -1,6 +1,6 @@
 {% extends './layouts/layout.njk' %}
 
-{% block pageTitle %}{% if errorMessage %}Error: {% endif %}Enter the CPH number for this {{ herdOrFlock }} - {{ serviceName }} - GOV.UK{% endblock %}
+{% block pageTitle %}{% if errorMessage %}Error: {% endif %}CPH number for livestock - {{ serviceName }} - GOV.UK{% endblock %}
 
 {% block containerStart %}
   {{ govukBackLink({

--- a/app/views/livestock/claim/enter-herd-details.njk
+++ b/app/views/livestock/claim/enter-herd-details.njk
@@ -1,6 +1,6 @@
 {% extends './layouts/layout.njk' %}
 
-{% block pageTitle %}{% if errorMessage %}Error: {% endif %}Enter the {{ herdOrFlock }} details - {{ serviceName }} - GOV.UK{% endblock %}
+{% block pageTitle %}{% if errorMessage %}Error: {% endif %}Livestock {{ herdOrFlock }} details - {{ serviceName }} - GOV.UK{% endblock %}
 
 {% block containerStart %}
   {{ govukBackLink({

--- a/app/views/livestock/claim/enter-herd-name.njk
+++ b/app/views/livestock/claim/enter-herd-name.njk
@@ -1,6 +1,6 @@
 {% extends './layouts/layout.njk' %}
 
-{% block pageTitle %}{% if errorMessage %}Error: {% endif %}Enter the {{ herdOrFlock }} name - {{ serviceName }} - GOV.UK{% endblock %}
+{% block pageTitle %}{% if errorMessage %}Error: {% endif %}Livestock {{ herdOrFlock }} name - {{ serviceName }} - GOV.UK{% endblock %}
 
 {% block containerStart %}
   {{ govukBackLink({

--- a/app/views/livestock/claim/herd-others-on-sbi.njk
+++ b/app/views/livestock/claim/herd-others-on-sbi.njk
@@ -1,6 +1,6 @@
 {% extends './layouts/layout.njk' %}
 
-{% block pageTitle %}{% if errorMessage %}Error: {% endif %}Is this the only {{ speciesGroupText }} associated with this Single Business Identifier (SBI)? - {{ serviceName }} - GOV.UK{% endblock %}
+{% block pageTitle %}{% if errorMessage %}Error: {% endif %}Livestock associated with this SBI - {{ serviceName }} - GOV.UK{% endblock %}
 
 {% block containerStart %}
   {{ govukBackLink({

--- a/app/views/livestock/claim/number-of-blood-samples.njk
+++ b/app/views/livestock/claim/number-of-blood-samples.njk
@@ -1,6 +1,6 @@
 {% extends './layouts/layout.njk' %}
 
-{% block pageTitle %}{% if errorMessage %}Error: {% endif %}How many blood samples were tested? - {{ serviceName }} - GOV.UK{% endblock %}
+{% block pageTitle %}{% if errorMessage %}Error: {% endif %}Number of livestock blood samples - {{ serviceName }} - GOV.UK{% endblock %}
 
 {% block containerStart %}
   {{ govukBackLink({

--- a/app/views/livestock/claim/number-of-fluid-oral-samples.njk
+++ b/app/views/livestock/claim/number-of-fluid-oral-samples.njk
@@ -1,6 +1,6 @@
 {% extends './layouts/layout.njk' %}
 
-{% block pageTitle %}{% if errorMessage %}Error: {% endif %}How many oral fluid samples were tested? - {{ serviceName }} - GOV.UK{% endblock %}
+{% block pageTitle %}{% if errorMessage %}Error: {% endif %}Number of livestock oral fluid samples - {{ serviceName }} - GOV.UK{% endblock %}
 
 {% block containerStart %}
   {{ govukBackLink({

--- a/app/views/livestock/claim/number-of-samples-tested.njk
+++ b/app/views/livestock/claim/number-of-samples-tested.njk
@@ -1,6 +1,6 @@
 {% extends './layouts/layout.njk' %}
 
-{% block pageTitle %}{% if errorMessage %}Error: {% endif %}How many samples were tested? - {{ serviceName }} - GOV.UK{% endblock %}
+{% block pageTitle %}{% if errorMessage %}Error: {% endif %}Number of livestock samples tested - {{ serviceName }} - GOV.UK{% endblock %}
 
 {% block containerStart %}
   {{ govukBackLink({

--- a/app/views/livestock/claim/number-of-species-tested.njk
+++ b/app/views/livestock/claim/number-of-species-tested.njk
@@ -1,6 +1,6 @@
 {% extends './layouts/layout.njk' %}
 
-{% block pageTitle %}{% if errorMessage %}Error: {% endif %}{{questionText}} - {{ serviceName }} - GOV.UK{% endblock %}
+{% block pageTitle %}{% if errorMessage %}Error: {% endif %}Number of animals livestock samples were taken from - {{ serviceName }} - GOV.UK{% endblock %}
 
 {% block containerStart %}
   {{ govukBackLink({

--- a/app/views/livestock/claim/pi-hunt-all-animals.njk
+++ b/app/views/livestock/claim/pi-hunt-all-animals.njk
@@ -1,6 +1,6 @@
 {% extends './layouts/layout.njk' %}
 
-{% block pageTitle %}{% if errorMessage %}Error: {% endif %}{{ title }} - {{ serviceName }} - GOV.UK{% endblock %}
+{% block pageTitle %}{% if errorMessage %}Error: {% endif %}Persistently infected hunt done on all livestock in herd - {{ serviceName }} - GOV.UK{% endblock %}
 
 {% block containerStart %}
   {{ govukBackLink({

--- a/app/views/livestock/claim/pi-hunt-recommended.njk
+++ b/app/views/livestock/claim/pi-hunt-recommended.njk
@@ -1,6 +1,6 @@
 {% extends './layouts/layout.njk' %}
 
-{% block pageTitle %}{% if errorMessage %}Error: {% endif %}{{ title }} - {{ serviceName }} - GOV.UK{% endblock %}
+{% block pageTitle %}{% if errorMessage %}Error: {% endif %}PI hunt recommended for livestock - {{ serviceName }} - GOV.UK{% endblock %}
 
 {% block containerStart %}
   {{ govukBackLink({

--- a/app/views/livestock/claim/pi-hunt.njk
+++ b/app/views/livestock/claim/pi-hunt.njk
@@ -1,6 +1,6 @@
 {% extends './layouts/layout.njk' %}
 
-{% block pageTitle %}{% if errorMessage %}Error: {% endif %}{{ titleText }} - {{ serviceName }} - GOV.UK{% endblock %}
+{% block pageTitle %}{% if errorMessage %}Error: {% endif %}Persistently infected hunt for bovine viral diarrhoea done on livestock - {{ serviceName }} - GOV.UK{% endblock %}
 
 {% block containerStart %}
   {{ govukBackLink({

--- a/app/views/livestock/claim/pigs-elisa-result.njk
+++ b/app/views/livestock/claim/pigs-elisa-result.njk
@@ -1,5 +1,5 @@
 {% extends './layouts/layout.njk' %} {% block pageTitle %}{% if errorMessage
-    %}Error: {% endif %}What was the result of the ELISA test? - {{ serviceName }} - GOV.UK{% endblock %}
+    %}Error: {% endif %}Pig livestock ELISA result - {{ serviceName }} - GOV.UK{% endblock %}
     {% block containerStart %}
     {{
       govukBackLink({

--- a/app/views/livestock/claim/pigs-genetic-sequencing.njk
+++ b/app/views/livestock/claim/pigs-genetic-sequencing.njk
@@ -1,5 +1,5 @@
 {% extends './layouts/layout.njk' %} {% block pageTitle %}{% if errorMessage
-%}Error: {% endif %}What was the result of the genetic sequencing? - {{ serviceName }} - GOV.UK{% endblock
+%}Error: {% endif %}Pig livestock genetic sequencing result - {{ serviceName }} - GOV.UK{% endblock
 %} {% block containerStart %}
 {{
   govukBackLink({

--- a/app/views/livestock/claim/pigs-pcr-result.njk
+++ b/app/views/livestock/claim/pigs-pcr-result.njk
@@ -1,5 +1,5 @@
 {% extends './layouts/layout.njk' %} {% block pageTitle %}{% if errorMessage
-  %}Error: {% endif %}What was the result of the PCR test? - {{ serviceName }} - GOV.UK{% endblock %}
+  %}Error: {% endif %}Pig livestock PCR test-result - {{ serviceName }} - GOV.UK{% endblock %}
   {% block containerStart %}
   {{
     govukBackLink({

--- a/app/views/livestock/claim/same-herd.njk
+++ b/app/views/livestock/claim/same-herd.njk
@@ -1,6 +1,6 @@
 {% extends './layouts/layout.njk' %}
 
-{% block pageTitle %}{% if errorMessage %}Error: {% endif %}Is this the same {{herdOrFlock}} you have previously claimed for? - {{serviceName}} - GOV.UK{% endblock %}
+{% block pageTitle %}{% if errorMessage %}Error: {% endif %}Previous {{ herdOrFlock }} livestock claim - {{serviceName}} - GOV.UK{% endblock %}
 
 {% block containerStart %}
   {{ govukBackLink({

--- a/app/views/livestock/claim/select-the-herd.njk
+++ b/app/views/livestock/claim/select-the-herd.njk
@@ -1,6 +1,6 @@
 {% extends './layouts/layout.njk' %}
 
-{% block pageTitle %}{% if errorMessage %}Error: {% endif %}{{pageTitleText}} - {{serviceName}} - GOV.UK{% endblock %}
+{% block pageTitle %}{% if errorMessage %}Error: {% endif %}{{ browserTitle }} - {{serviceName}} - GOV.UK{% endblock %}
 
 {% block containerStart %}
   {{ govukBackLink({

--- a/app/views/livestock/claim/sheep-endemics-package.njk
+++ b/app/views/livestock/claim/sheep-endemics-package.njk
@@ -1,6 +1,6 @@
 {% extends './layouts/layout.njk' %}
 
-{% block pageTitle %}{% if errorMessage %}Error: {% endif %}{{ pageHeading }} - {{ serviceName }} - GOV.UK{% endblock %}
+{% block pageTitle %}{% if errorMessage %}Error: {% endif %}Sheep livestock health package - {{ serviceName }} - GOV.UK{% endblock %}
 
 {% block containerStart %}
   {{ govukBackLink({

--- a/app/views/livestock/claim/sheep-test-results.njk
+++ b/app/views/livestock/claim/sheep-test-results.njk
@@ -1,6 +1,6 @@
 {% extends './layouts/layout.njk' %}
 
-{% block pageTitle %}{% if errorList | length %}Error: {% endif %}{{ pageTitle }} - {{ serviceName }} - GOV.UK{% endblock %}
+{% block pageTitle %}{% if errorList | length %}Error: {% endif %}Sheep livestock test result - {{ serviceName }} - GOV.UK{% endblock %}
 
 {% block containerStart %}
   {{ govukBackLink({

--- a/app/views/livestock/claim/sheep-tests.njk
+++ b/app/views/livestock/claim/sheep-tests.njk
@@ -1,6 +1,6 @@
 {% extends './layouts/layout.njk' %}
 
-{% block pageTitle %}{% if errorMessage %}Error: {% endif %}Which disease or condition did the vet take samples to test for? - {{ serviceName }} - GOV.UK{% endblock %}
+{% block pageTitle %}{% if errorMessage %}Error: {% endif %}Sheep livestock disease or condition samples - {{ serviceName }} - GOV.UK{% endblock %}
 
 {% block containerStart %}
   {{ govukBackLink({

--- a/app/views/livestock/claim/test-results.njk
+++ b/app/views/livestock/claim/test-results.njk
@@ -1,6 +1,6 @@
 {% extends './layouts/layout.njk' %}
 
-{% block pageTitle %}{% if errorMessage %}Error: {% endif %}{{ title }} - {{ serviceName }} - GOV.UK{% endblock %}
+{% block pageTitle %}{% if errorMessage %}Error: {% endif %}Livestock test result - {{ serviceName }} - GOV.UK{% endblock %}
 
 {% block containerStart %}
   {{ govukBackLink({

--- a/app/views/livestock/claim/test-urn.njk
+++ b/app/views/livestock/claim/test-urn.njk
@@ -1,6 +1,6 @@
 {% extends './layouts/layout.njk' %}
 
-{% block pageTitle %}{% if errorMessage %}Error: {% endif %}{{ title }} - {{ serviceName }} - GOV.UK{% endblock %}
+{% block pageTitle %}{% if errorMessage %}Error: {% endif %}Livestock laboratory's unique reference number - {{ serviceName }} - GOV.UK{% endblock %}
 
 {% block containerStart %}
   {{ govukBackLink({

--- a/app/views/livestock/claim/type-of-samples-taken.njk
+++ b/app/views/livestock/claim/type-of-samples-taken.njk
@@ -1,6 +1,6 @@
 {% extends './layouts/layout.njk' %}
 
-{% block pageTitle %}{% if errorMessage %}Error: {% endif %}What type of samples were taken? - {{ serviceName }} - GOV.UK{% endblock %}
+{% block pageTitle %}{% if errorMessage %}Error: {% endif %}Type of livestock samples - {{ serviceName }} - GOV.UK{% endblock %}
 
 {% block containerStart %}
   {{ govukBackLink({

--- a/app/views/livestock/claim/vaccination.njk
+++ b/app/views/livestock/claim/vaccination.njk
@@ -1,6 +1,6 @@
 {% extends './layouts/layout.njk' %}
 
-{% block pageTitle %}{% if errorMessage %}Error: {% endif %}Herd Vaccination Status - {{ serviceName }} - GOV.UK{% endblock %}
+{% block pageTitle %}{% if errorMessage %}Error: {% endif %}Livestock vaccination - {{ serviceName }} - GOV.UK{% endblock %}
 
 {% block containerStart %}
   {{ govukBackLink({

--- a/app/views/livestock/claim/vet-name.njk
+++ b/app/views/livestock/claim/vet-name.njk
@@ -1,6 +1,6 @@
 {% extends './layouts/layout.njk' %}
 
-{% block pageTitle %}{% if errorMessage %}Error: {% endif %}What is the vet's name? - {{ serviceName }} - GOV.UK{% endblock %}
+{% block pageTitle %}{% if errorMessage %}Error: {% endif %}Livestock vet's name - {{ serviceName }} - GOV.UK{% endblock %}
 
 {% block containerStart %}
   {{ govukBackLink({

--- a/app/views/livestock/claim/vet-rcvs.njk
+++ b/app/views/livestock/claim/vet-rcvs.njk
@@ -1,6 +1,6 @@
 {% extends './layouts/layout.njk' %}
 
-{% block pageTitle %}{% if errorMessage %}Error: {% endif %}What is the vet's Royal College of Veterinary Surgeons (RCVS) number? - {{ serviceName }} - GOV.UK{% endblock %}
+{% block pageTitle %}{% if errorMessage %}Error: {% endif %}Livestock vet's RCVS number - {{ serviceName }} - GOV.UK{% endblock %}
 
 {% block containerStart %}
   {{ govukBackLink({

--- a/app/views/livestock/claim/vet-visits-review-test-results.njk
+++ b/app/views/livestock/claim/vet-visits-review-test-results.njk
@@ -1,6 +1,6 @@
 {% extends './layouts/layout.njk' %}
 
-{% block pageTitle %}{% if errorMessage %}Error: {% endif %}Vet Visits Review Test Results - {{ serviceName }} - GOV.UK{% endblock %}
+{% block pageTitle %}{% if errorMessage %}Error: {% endif %}Livestock test results - {{ serviceName }} - GOV.UK{% endblock %}
 
 {% block containerStart %}
   {{ govukBackLink({

--- a/app/views/livestock/claim/which-species.njk
+++ b/app/views/livestock/claim/which-species.njk
@@ -1,6 +1,6 @@
 {% extends './layouts/layout.njk' %}
 
-{% block pageTitle %}{% if errorMessage %}Error: {% endif %}Which species are you claiming for? - {{ serviceName }} - GOV.UK{% endblock %}
+{% block pageTitle %}{% if errorMessage %}Error: {% endif %}Which livestock species are you claiming for? - {{ serviceName }} - GOV.UK{% endblock %}
 
 {% block containerStart %}
   {{ govukBackLink({

--- a/app/views/livestock/claim/which-type-of-review.njk
+++ b/app/views/livestock/claim/which-type-of-review.njk
@@ -1,6 +1,6 @@
 {% extends './layouts/layout.njk' %}
 
-{% block pageTitle %}{% if errorMessage %}Error: {% endif %}Are you claiming for a review or follow-up? - {{ serviceName }} - GOV.UK{% endblock %}
+{% block pageTitle %}{% if errorMessage %}Error: {% endif %}Are you claiming for a livestock review or follow-up? - {{ serviceName }} - GOV.UK{% endblock %}
 
 {% block containerStart %}
   {{ govukBackLink({

--- a/app/views/livestock/vet-visits.njk
+++ b/app/views/livestock/vet-visits.njk
@@ -2,7 +2,7 @@
 {% from "./macros/organisation-header.njk" import organisationHeader %}
 {% set mainClasses = "govuk-!-padding-top-2" %}
 
-{% block pageTitle %}Manage your claims - {{ serviceName }} - GOV.UK{% endblock %}
+{% block pageTitle %}Manage your livestock claims - {{ serviceName }} - GOV.UK{% endblock %}
 
 {% set spanText = "(column headers with buttons are sortable by ascending or descending order)." %}
 

--- a/test/integration/narrow/routes/livestock/apply/declaration.test.js
+++ b/test/integration/narrow/routes/livestock/apply/declaration.test.js
@@ -108,7 +108,7 @@ describe("Declaration test", () => {
       const $ = cheerio.load(res.payload);
       expect($("h1").text()).toMatch("Review your agreement offer");
       expect($("title").text()).toMatch(
-        "Review your agreement offer - Get funding to improve animal health and welfare",
+        "Review your livestock agreement offer - Get funding to improve animal health and welfare",
       );
       ok($);
       const expectedHerdsText = `If the RPA requests evidence that your reviews or follow-ups took place, or details of the herd or flocks you have, you must provide it. This will be on your vet summary.`;
@@ -142,7 +142,7 @@ describe("Declaration test", () => {
       const $ = cheerio.load(res.payload);
       expect($("h1").text()).toMatch("Application complete");
       expect($("title").text()).toMatch(
-        "Application complete - Get funding to improve animal health and welfare",
+        "Livestock application complete - Get funding to improve animal health and welfare",
       );
       ok($);
       expect(clearApplyRedirect).toHaveBeenCalled();
@@ -185,7 +185,7 @@ describe("Declaration test", () => {
       );
       const $ = cheerio.load(res.payload);
       expect($("title").text()).toMatch(
-        "Agreement offer rejected - Get funding to improve animal health and welfare",
+        "Livestock agreement offer rejected - Get funding to improve animal health and welfare",
       );
       ok($);
       expect(createApplication).toHaveBeenCalledWith(
@@ -224,7 +224,7 @@ describe("Declaration test", () => {
       const $ = cheerio.load(res.payload);
       expect($("h1.govuk-heading-l").text()).toEqual("Review your agreement offer");
       expect($("title").text()).toMatch(
-        "Review your agreement offer - Get funding to improve animal health and welfare",
+        "Review your livestock agreement offer - Get funding to improve animal health and welfare",
       );
       expect($("#organisation-name").text()).toEqual(organisation.name);
       expect($("#organisation-address").text()).toContain("1 fake street");

--- a/test/integration/narrow/routes/livestock/apply/numbers.test.js
+++ b/test/integration/narrow/routes/livestock/apply/numbers.test.js
@@ -68,14 +68,15 @@ describe("Check review numbers page test", () => {
 
       const $ = cheerio.load(res.payload);
       const titleClassName = ".govuk-heading-l";
-      const title = "Minimum number of each species in each herd or flock";
+      const heading = "Minimum number of each species in each herd or flock";
+      const title = "Minimum number of livestock";
       const pageTitleByClassName = $(titleClassName).text();
       const pageTitleByName = $("title").text();
       const fullTitle = `${title} - Get funding to improve animal health and welfare`;
       const backLinkUrlByClassName = $(".govuk-back-link").attr("href");
 
       expect(pageTitleByName).toContain(fullTitle);
-      expect(pageTitleByClassName).toEqual(title);
+      expect(pageTitleByClassName).toEqual(heading);
       expect(backLinkUrlByClassName).toContain(applyRoutes.youCanClaimMultiple);
       ok($);
     });

--- a/test/integration/narrow/routes/livestock/apply/timings.test.js
+++ b/test/integration/narrow/routes/livestock/apply/timings.test.js
@@ -70,7 +70,7 @@ describe("Declaration test", () => {
       const $ = cheerio.load(res.payload);
       expect($("h1").text()).toMatch("Timing of reviews and follow-ups");
       expect($("title").text()).toMatch(
-        "Timing of reviews and follow-ups - Get funding to improve animal health and welfare",
+        "Timing of livestock reviews and follow-ups - Get funding to improve animal health and welfare",
       );
       expect($("main h2").length).toBe(2);
 

--- a/test/integration/narrow/routes/livestock/apply/you-can-claim-multiple.test.js
+++ b/test/integration/narrow/routes/livestock/apply/you-can-claim-multiple.test.js
@@ -72,6 +72,10 @@ describe("you-can-claim-multiple page", () => {
 
       expect(await axe(res.payload)).toHaveNoViolations();
       expect(res.statusCode).toBe(StatusCodes.OK);
+      expect(res.payload).toContain(
+        "What you can claim for a livestock agreement - Get funding to improve animal health and welfare",
+      );
+      expect(res.payload).toContain("What you can claim for as part of this agreement"); // h1 unchanged
       expect(res.payload).toContain("/check-details"); // back-link
       expect(setSessionData).toHaveBeenCalledWith(
         expect.anything(),

--- a/test/integration/narrow/routes/livestock/claim/assurance-scheme.test.js
+++ b/test/integration/narrow/routes/livestock/claim/assurance-scheme.test.js
@@ -92,6 +92,11 @@ describe("Assurance Scheme", () => {
 
       expect(await axe(response.payload)).toHaveNoViolations();
       expect(response.statusCode).toBe(200);
+      const $ = cheerio.load(response.payload);
+      expect($("title").text().trim()).toContain(
+        "Livestock biosecurity assessment - Get funding to improve animal health and welfare",
+      );
+      expect($("h1").text().trim()).toBe("Is this flock part of an Assurance Scheme?");
     });
   });
 

--- a/test/integration/narrow/routes/livestock/claim/biosecurity.test.js
+++ b/test/integration/narrow/routes/livestock/claim/biosecurity.test.js
@@ -132,7 +132,7 @@ describe("Biosecurity test when Optional PI Hunt is OFF", () => {
       expect(await axe(response.payload)).toHaveNoViolations();
       const $ = cheerio.load(response.payload);
       expect($("title").text()).toMatch(
-        "Did the vet do a biosecurity assessment? - Get funding to improve animal health and welfare",
+        "Livestock biosecurity assessment - Get funding to improve animal health and welfare",
       );
       expect($("h1").text()).toMatch("Did the vet do a biosecurity assessment?");
     });

--- a/test/integration/narrow/routes/livestock/claim/check-answers.test.js
+++ b/test/integration/narrow/routes/livestock/claim/check-answers.test.js
@@ -155,7 +155,7 @@ describe("Check answers test", () => {
 
       expect($("h1").text()).toMatch("Check your answers");
       expect($("title").text()).toMatch(
-        "Check your answers - Get funding to improve animal health and welfare",
+        "Check your answers before submitting your livestock claim - Get funding to improve animal health and welfare",
       );
       expect(res.statusCode).toBe(200);
 
@@ -639,7 +639,7 @@ describe("Check answers test", () => {
 
         expect($("h1").text()).toMatch("Check your answers");
         expect($("title").text()).toMatch(
-          "Check your answers - Get funding to improve animal health and welfare",
+          "Check your answers before submitting your livestock claim - Get funding to improve animal health and welfare",
         );
         expect($(".govuk-summary-list__key").text()).toContain(content);
         expect($(".govuk-summary-list__value").text()).toContain("SpeciesNumbers");
@@ -680,7 +680,7 @@ describe("Check answers test", () => {
 
       expect($("h1").text()).toMatch("Check your answers");
       expect($("title").text()).toMatch(
-        "Check your answers - Get funding to improve animal health and welfare",
+        "Check your answers before submitting your livestock claim - Get funding to improve animal health and welfare",
       );
       expect($(".govuk-summary-list__key").text()).not.toContain("Test results\n");
       expect($(".govuk-summary-list__value").text()).not.toContain("TestResults");
@@ -729,7 +729,7 @@ describe("Check answers test", () => {
 
         expect($("h1").text()).toMatch("Check your answers");
         expect($("title").text()).toMatch(
-          "Check your answers - Get funding to improve animal health and welfare",
+          "Check your answers before submitting your livestock claim - Get funding to improve animal health and welfare",
         );
         expect($(".govuk-summary-list__key").text()).toContain("Review test result");
         expect($(".govuk-summary-list__value").text()).toContain("VetVisitsReviewTestResults");

--- a/test/integration/narrow/routes/livestock/claim/check-herd-details.test.js
+++ b/test/integration/narrow/routes/livestock/claim/check-herd-details.test.js
@@ -93,7 +93,7 @@ describe("/livestock/check-herd-details tests", () => {
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
       expect($("title").text().trim()).toContain(
-        "Check herd details - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
+        "Check livestock herd details - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
       );
       expect($(".govuk-back-link").attr("href")).toContain("/livestock/enter-herd-details");
       expect(assertLinkExistsFor($, "CPH number")).toBeTruthy();
@@ -124,7 +124,7 @@ describe("/livestock/check-herd-details tests", () => {
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
       expect($("title").text().trim()).toContain(
-        "Check flock details - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
+        "Check livestock flock details - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
       );
       expect($(".govuk-back-link").attr("href")).toContain("/livestock/enter-herd-details");
       expect(assertLinkExistsFor($, "CPH number")).toBeTruthy();
@@ -155,7 +155,7 @@ describe("/livestock/check-herd-details tests", () => {
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
       expect($("title").text().trim()).toContain(
-        "Check herd details - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
+        "Check livestock herd details - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
       );
       expect($(".govuk-back-link").attr("href")).toContain("/livestock/sbi-herds");
       expect(assertLinkExistsFor($, "CPH number")).toBeTruthy();
@@ -185,7 +185,7 @@ describe("/livestock/check-herd-details tests", () => {
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
       expect($("title").text().trim()).toContain(
-        "Check herd details - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
+        "Check livestock herd details - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
       );
       expect($(".govuk-back-link").attr("href")).toContain("/livestock/enter-herd-details");
       expect(assertLinkExistsFor($, "CPH number")).toBeTruthy();
@@ -221,7 +221,7 @@ describe("/livestock/check-herd-details tests", () => {
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
       expect($("title").text().trim()).toContain(
-        "Check herd details - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
+        "Check livestock herd details - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
       );
       expect($(".govuk-back-link").attr("href")).toContain("/livestock/enter-herd-details");
       expect(assertLinkExistsFor($, "CPH number")).toBeTruthy();
@@ -253,7 +253,7 @@ describe("/livestock/check-herd-details tests", () => {
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
       expect($("title").text().trim()).toContain(
-        "Check herd details - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
+        "Check livestock herd details - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
       );
       expect($(".govuk-back-link").attr("href")).toContain("/livestock/enter-herd-details");
       expect(assertLinkExistsFor($, "CPH number")).toBeTruthy();
@@ -289,7 +289,7 @@ describe("/livestock/check-herd-details tests", () => {
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
       expect($("title").text().trim()).toContain(
-        "Check herd details - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
+        "Check livestock herd details - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
       );
       expect($(".govuk-back-link").attr("href")).toContain("/livestock/enter-herd-details");
       expect(assertLinkExistsFor($, "CPH number")).toBeTruthy();

--- a/test/integration/narrow/routes/livestock/claim/confirmation.test.js
+++ b/test/integration/narrow/routes/livestock/claim/confirmation.test.js
@@ -80,6 +80,10 @@ describe("Claim confirmation", () => {
       const $ = cheerio.load(res.payload);
 
       expect(res.statusCode).toBe(200);
+      expect($("h1").text()).toContain("Claim complete");
+      expect($("title").text()).toContain(
+        "Livestock claim submitted - Get funding to improve animal health and welfare",
+      );
       expect($("#amount").text()).toContain("55");
       expect($("#reference").text().trim()).toEqual(reference);
       expect($("#message").text().trim()).toContain(

--- a/test/integration/narrow/routes/livestock/claim/date-of-testing.test.js
+++ b/test/integration/narrow/routes/livestock/claim/date-of-testing.test.js
@@ -112,6 +112,10 @@ describe("Date of testing", () => {
         expect(await axe(res.payload)).toHaveNoViolations();
         expect(res.statusCode).toBe(HttpStatus.OK);
         const $ = cheerio.load(res.payload);
+        expect($("h1").text()).toMatch("When were samples taken?");
+        expect($("title").text()).toContain(
+          "When livestock samples were taken - Get funding to improve animal health and welfare",
+        );
         expect($(".govuk-back-link").attr("href")).toMatch("/livestock/pi-hunt-all-animals");
         expectPhaseBanner.ok($);
         expect($("#whenTestingWasCarriedOut-hint").text()).toMatch(

--- a/test/integration/narrow/routes/livestock/claim/date-of-visit.test.js
+++ b/test/integration/narrow/routes/livestock/claim/date-of-visit.test.js
@@ -25,7 +25,7 @@ jest.mock("../../../../../../app/logging/logger.js", () => ({
 
 function expectPageContentOk($, previousPageUrl) {
   expect($("title").text()).toMatch(
-    /Date of review|follow-up - Get funding to improve animal health and welfare/i,
+    /Date of livestock review|follow-up - Get funding to improve animal health and welfare/i,
   );
   expect($("h1").text().trim()).toMatch(/(Date of review | follow-up)/i);
   expect($("p").text()).toMatch(
@@ -219,7 +219,7 @@ describe("GET /livestock/date-of-visit handler", () => {
     expect(res.statusCode).toBe(200);
     const $ = cheerio.load(res.payload);
     expect($("h1").text().trim()).toBe("Date of follow-up");
-    expect($("title").text()).toMatch(/^Date of follow-up - /);
+    expect($("title").text()).toMatch(/^Date of livestock follow-up - /);
     expect($(".govuk-back-link").attr("href")).toBe("/livestock/vet-visits-review-test-results");
     expectPhaseBanner.ok($);
   });
@@ -247,7 +247,7 @@ describe("GET /livestock/date-of-visit handler", () => {
     expect(res.statusCode).toBe(200);
     const $ = cheerio.load(res.payload);
     expect($("h1").text().trim()).toBe("Date of review");
-    expect($("title").text()).toMatch(/^Date of review - /);
+    expect($("title").text()).toMatch(/^Date of livestock review - /);
     expect($(".govuk-back-link").attr("href")).toBe("/livestock/review-type");
     expectPhaseBanner.ok($);
   });

--- a/test/integration/narrow/routes/livestock/claim/disease-status.test.js
+++ b/test/integration/narrow/routes/livestock/claim/disease-status.test.js
@@ -103,6 +103,9 @@ describe("Disease status test", () => {
       expect(await axe(response.payload)).toHaveNoViolations();
       const $ = cheerio.load(response.payload);
       expect($("h1").text()).toMatch("What is the disease status category?");
+      expect($("title").text()).toContain(
+        "Livestock disease status - Get funding to improve animal health and welfare",
+      );
     });
 
     test("select '1' when diseaseStatus is '1'", async () => {

--- a/test/integration/narrow/routes/livestock/claim/endemics-package.test.js
+++ b/test/integration/narrow/routes/livestock/claim/endemics-package.test.js
@@ -71,7 +71,7 @@ describe("Endemics package test", () => {
       const $ = cheerio.load(res.payload);
       expect($("h1").text().trim()).toMatch("Which sheep health package did you choose?");
       expect($("title").text()).toContain(
-        "Which sheep health package did you choose? - Get funding to improve animal health and welfare",
+        "Sheep livestock health package - Get funding to improve animal health and welfare",
       );
 
       expectPhaseBanner.ok($);

--- a/test/integration/narrow/routes/livestock/claim/enter-cph-number.test.js
+++ b/test/integration/narrow/routes/livestock/claim/enter-cph-number.test.js
@@ -65,7 +65,7 @@ describe("/livestock/cph tests", () => {
 
   const expectHerdText = ($) => {
     expect($("title").text().trim()).toContain(
-      "Enter the CPH number for this herd - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
+      "CPH number for livestock - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
     );
     expect($(".govuk-heading-l").text().trim()).toBe(
       "Enter the County Parish Holding (CPH) number for this herd",
@@ -75,7 +75,7 @@ describe("/livestock/cph tests", () => {
 
   const expectFlockText = ($) => {
     expect($("title").text().trim()).toContain(
-      "Enter the CPH number for this flock - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
+      "CPH number for livestock - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
     );
     expect($(".govuk-heading-l").text().trim()).toBe(
       "Enter the County Parish Holding (CPH) number for this flock",

--- a/test/integration/narrow/routes/livestock/claim/enter-herd-details.test.js
+++ b/test/integration/narrow/routes/livestock/claim/enter-herd-details.test.js
@@ -80,7 +80,7 @@ describe("/livestock/enter-herd-details tests", () => {
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
       expect($("title").text().trim()).toContain(
-        "Enter the herd details - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
+        "Livestock herd details - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
       );
       expect($(".govuk-back-link").attr("href")).toContain("/livestock/sbi-herds");
       expect($(".govuk-heading-l").text().trim()).toBe("Enter the herd details");
@@ -120,7 +120,7 @@ describe("/livestock/enter-herd-details tests", () => {
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
       expect($("title").text().trim()).toContain(
-        "Enter the herd details - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
+        "Livestock herd details - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
       );
       expect($(".govuk-back-link").attr("href")).toContain("/livestock/sbi-herds");
       expect($('.govuk-checkboxes__input[value="differentBreed"]').is(":checked")).toBeTruthy();
@@ -143,7 +143,7 @@ describe("/livestock/enter-herd-details tests", () => {
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
       expect($("title").text().trim()).toContain(
-        "Enter the flock details - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
+        "Livestock flock details - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
       );
       expect($(".govuk-back-link").attr("href")).toContain("/livestock/sbi-herds");
       expect($(".govuk-heading-l").text().trim()).toBe("Enter the flock details");
@@ -172,7 +172,7 @@ describe("/livestock/enter-herd-details tests", () => {
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
       expect($("title").text().trim()).toContain(
-        "Enter the herd details - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
+        "Livestock herd details - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
       );
       expect($(".govuk-back-link").attr("href")).toContain("/livestock/cph");
       expect($(".govuk-heading-l").text().trim()).toBe("Enter the herd details");
@@ -201,7 +201,7 @@ describe("/livestock/enter-herd-details tests", () => {
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
       expect($("title").text().trim()).toContain(
-        "Enter the herd details - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
+        "Livestock herd details - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
       );
       expect($(".govuk-back-link").attr("href")).toContain("/livestock/sbi-herds");
       expect($(".govuk-heading-l").text().trim()).toBe("Enter the herd details");

--- a/test/integration/narrow/routes/livestock/claim/enter-herd-name.test.js
+++ b/test/integration/narrow/routes/livestock/claim/enter-herd-name.test.js
@@ -65,7 +65,7 @@ describe("/livestock/herd-name tests", () => {
 
   const expectHerdText = ($) => {
     expect($("title").text().trim()).toContain(
-      "Enter the herd name - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
+      "Livestock herd name - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
     );
     expect($(".govuk-label--l").text().trim()).toBe("Enter the herd name");
     expect($(".govuk-hint").text().trim()).toContain("Tell us about this herd");
@@ -78,7 +78,7 @@ describe("/livestock/herd-name tests", () => {
 
   const expectFlockText = ($) => {
     expect($("title").text().trim()).toContain(
-      "Enter the flock name - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
+      "Livestock flock name - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
     );
     expect($(".govuk-label--l").text().trim()).toBe("Enter the flock name");
     expect($(".govuk-hint").text().trim()).toContain("Tell us about this flock");

--- a/test/integration/narrow/routes/livestock/claim/herd-others-on-sbi.test.js
+++ b/test/integration/narrow/routes/livestock/claim/herd-others-on-sbi.test.js
@@ -79,7 +79,7 @@ describe("/livestock/sbi-herds tests", () => {
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
       expect($("title").text().trim()).toContain(
-        "Is this the only beef cattle herd associated with this Single Business Identifier (SBI)? - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
+        "Livestock associated with this SBI - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
       );
       expect($(".govuk-back-link").attr("href")).toContain("/livestock/cph");
       expect($(".govuk-hint").text()).toContain("Tell us about this herd");
@@ -106,7 +106,7 @@ describe("/livestock/sbi-herds tests", () => {
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
       expect($("title").text().trim()).toContain(
-        "Is this the only beef cattle herd associated with this Single Business Identifier (SBI)? - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
+        "Livestock associated with this SBI - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
       );
       expect($(".govuk-back-link").attr("href")).toContain("/livestock/cph");
       expect($('.govuk-radios__input[value="no"]').is(":checked")).toBeTruthy();
@@ -128,7 +128,7 @@ describe("/livestock/sbi-herds tests", () => {
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
       expect($("title").text().trim()).toContain(
-        "Is this the only flock of sheep associated with this Single Business Identifier (SBI)? - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
+        "Livestock associated with this SBI - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
       );
       expect($(".govuk-back-link").attr("href")).toContain("/livestock/cph");
       expect($(".govuk-hint").text()).toContain("Tell us about this flock");
@@ -154,7 +154,7 @@ describe("/livestock/sbi-herds tests", () => {
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
       expect($("title").text().trim()).toContain(
-        "Is this the only dairy cattle herd associated with this Single Business Identifier (SBI)? - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
+        "Livestock associated with this SBI - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
       );
       expect($(".govuk-back-link").attr("href")).toContain("/livestock/cph");
       expect($(".govuk-hint").text()).toContain("Tell us about this herd");
@@ -180,7 +180,7 @@ describe("/livestock/sbi-herds tests", () => {
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
       expect($("title").text().trim()).toContain(
-        "Is this the only pigs herd associated with this Single Business Identifier (SBI)? - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
+        "Livestock associated with this SBI - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
       );
       expect($(".govuk-back-link").attr("href")).toContain("/livestock/cph");
       expect($(".govuk-hint").text()).toContain("Tell us about this herd");
@@ -283,7 +283,7 @@ describe("/livestock/sbi-herds tests", () => {
         "Select yes if this is the only flock of sheep associated with this SBI",
       );
       expect($("title").text().trim()).toContain(
-        "Is this the only flock of sheep associated with this Single Business Identifier (SBI)? - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
+        "Livestock associated with this SBI - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
       );
       expect($(".govuk-hint").text()).toContain("Tell us about this flock");
       expect(emitHerdEvent).not.toHaveBeenCalled();
@@ -312,7 +312,7 @@ describe("/livestock/sbi-herds tests", () => {
         "Select yes if this is the only beef cattle herd associated with this SBI",
       );
       expect($("title").text().trim()).toContain(
-        "Is this the only beef cattle herd associated with this Single Business Identifier (SBI)? - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
+        "Livestock associated with this SBI - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
       );
       expect($(".govuk-hint").text()).toContain("Tell us about this herd");
       expect(emitHerdEvent).not.toHaveBeenCalled();

--- a/test/integration/narrow/routes/livestock/claim/number-of-blood-samples.test.js
+++ b/test/integration/narrow/routes/livestock/claim/number-of-blood-samples.test.js
@@ -77,7 +77,7 @@ describe("Number of blood samples test", () => {
       const $ = cheerio.load(res.payload);
       expect($("h1").text()).toMatch("How many blood samples were tested?");
       expect($("title").text()).toContain(
-        "How many blood samples were tested? - Get funding to improve animal health and welfare",
+        "Number of livestock blood samples - Get funding to improve animal health and welfare",
       );
       expectPhaseBanner.ok($);
     });

--- a/test/integration/narrow/routes/livestock/claim/number-of-fluid-oral-samples.test.js
+++ b/test/integration/narrow/routes/livestock/claim/number-of-fluid-oral-samples.test.js
@@ -72,7 +72,7 @@ describe("Number of fluid oral samples test", () => {
       const $ = cheerio.load(res.payload);
       expect($("h1").text()).toMatch("How many oral fluid samples were tested?");
       expect($("title").text()).toContain(
-        "How many oral fluid samples were tested? - Get funding to improve animal health and welfare",
+        "Number of livestock oral fluid samples - Get funding to improve animal health and welfare",
       );
       expect($("#back").attr("href")).toBe("/livestock/test-urn");
       expectPhaseBanner.ok($);
@@ -94,7 +94,7 @@ describe("Number of fluid oral samples test", () => {
       const $ = cheerio.load(res.payload);
       expect($("h1").text()).toMatch("How many oral fluid samples were tested?");
       expect($("title").text()).toContain(
-        "How many oral fluid samples were tested? - Get funding to improve animal health and welfare",
+        "Number of livestock oral fluid samples - Get funding to improve animal health and welfare",
       );
       expect($("#back").attr("href")).toBe("/livestock/samples-types");
       expectPhaseBanner.ok($);

--- a/test/integration/narrow/routes/livestock/claim/number-of-samples-tested.test.js
+++ b/test/integration/narrow/routes/livestock/claim/number-of-samples-tested.test.js
@@ -72,7 +72,7 @@ describe("Number of samples tested test", () => {
       const $ = cheerio.load(res.payload);
       expect($("h1").text()).toMatch("How many samples were tested?");
       expect($("title").text()).toContain(
-        "How many samples were tested? - Get funding to improve animal health and welfare",
+        "Number of livestock samples tested - Get funding to improve animal health and welfare",
       );
       expect($(".govuk-hint").text().trim()).toEqual(
         "Enter how many polymerase chain reaction (PCR) and enzyme-linked immunosorbent assay (ELISA) test results you got back. You can find this on the summary the vet gave you.",

--- a/test/integration/narrow/routes/livestock/claim/number-of-species-tested.test.js
+++ b/test/integration/narrow/routes/livestock/claim/number-of-species-tested.test.js
@@ -79,7 +79,7 @@ describe("Number of species tested test", () => {
       const $ = cheerio.load(res.payload);
       expect($("h1").text()).toMatch("How many animals were samples taken from?");
       expect($("title").text().trim()).toContain(
-        "How many animals were samples taken from? - Get funding to improve animal health and welfare",
+        "Number of animals livestock samples were taken from - Get funding to improve animal health and welfare",
       );
       expectPhaseBanner.ok($);
     });

--- a/test/integration/narrow/routes/livestock/claim/pi-hunt-all-animals.test.js
+++ b/test/integration/narrow/routes/livestock/claim/pi-hunt-all-animals.test.js
@@ -92,6 +92,9 @@ describe("PI Hunt recommended tests", () => {
 
         expect(res.statusCode).toBe(200);
         expect($(".govuk-fieldset__heading").text().trim()).toEqual(expectedQuestion);
+        expect($("title").text()).toContain(
+          "Persistently infected hunt done on all livestock in herd - Get funding to improve animal health and welfare",
+        );
         expect($(".govuk-radios__item").length).toEqual(2);
         expect($(".govuk-back-link").attr("href")).toContain(backLink);
         expectPhaseBanner.ok($);

--- a/test/integration/narrow/routes/livestock/claim/pi-hunt-recommended.test.js
+++ b/test/integration/narrow/routes/livestock/claim/pi-hunt-recommended.test.js
@@ -74,6 +74,9 @@ describe("PI Hunt recommended tests", () => {
       expect($(".govuk-fieldset__heading").text().trim()).toEqual(
         "Was the PI hunt recommended by the vet?",
       );
+      expect($("title").text()).toContain(
+        "PI hunt recommended for livestock - Get funding to improve animal health and welfare",
+      );
       expect($(".govuk-radios__item").length).toEqual(2);
       expectPhaseBanner.ok($);
     });

--- a/test/integration/narrow/routes/livestock/claim/pi-hunt.test.js
+++ b/test/integration/narrow/routes/livestock/claim/pi-hunt.test.js
@@ -83,7 +83,7 @@ describe("PI Hunt tests when Optional PI Hunt is OFF", () => {
         "Was a persistently infected (PI) hunt for bovine viral diarrhoea (BVD) done on all animals in the herd?",
       );
       expect($("title").text().trim()).toContain(
-        "Was a persistently infected (PI) hunt for bovine viral diarrhoea (BVD) done on all animals in the herd? - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
+        "Persistently infected hunt for bovine viral diarrhoea done on livestock - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
       );
       expect($(".govuk-radios__item").length).toEqual(2);
       expectPhaseBanner.ok($);

--- a/test/integration/narrow/routes/livestock/claim/pigs-elisa-result.test.js
+++ b/test/integration/narrow/routes/livestock/claim/pigs-elisa-result.test.js
@@ -74,7 +74,7 @@ describe("pigs elisa result test", () => {
       const $ = cheerio.load(res.payload);
       expect($("h1").text()).toMatch("What was the result of the ELISA test?");
       expect($("title").text()).toContain(
-        "What was the result of the ELISA test? - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
+        "Pig livestock ELISA result - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
       );
 
       expectPhaseBanner.ok($);

--- a/test/integration/narrow/routes/livestock/claim/pigs-genetic-sequencing.test.js
+++ b/test/integration/narrow/routes/livestock/claim/pigs-genetic-sequencing.test.js
@@ -71,7 +71,7 @@ describe("pigs genetic sequencing test", () => {
       const $ = cheerio.load(res.payload);
       expect($("h1").text()).toMatch(" What was the result of the genetic sequencing?");
       expect($("title").text()).toContain(
-        "What was the result of the genetic sequencing? - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
+        "Pig livestock genetic sequencing result - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
       );
 
       expectPhaseBanner.ok($);

--- a/test/integration/narrow/routes/livestock/claim/pigs-pcr-result.test.js
+++ b/test/integration/narrow/routes/livestock/claim/pigs-pcr-result.test.js
@@ -71,7 +71,7 @@ describe("pigs pcr result test", () => {
       const $ = cheerio.load(res.payload);
       expect($("h1").text()).toMatch("What was the result of the PCR test?");
       expect($("title").text()).toContain(
-        "What was the result of the PCR test? - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
+        "Pig livestock PCR test-result - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
       );
 
       expectPhaseBanner.ok($);

--- a/test/integration/narrow/routes/livestock/claim/same-herd.test.js
+++ b/test/integration/narrow/routes/livestock/claim/same-herd.test.js
@@ -110,7 +110,7 @@ describe("select-the-herd tests", () => {
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
       expect($("title").text().trim()).toContain(
-        "Is this the same flock you have previously claimed for? - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
+        "Previous flock livestock claim - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
       );
       expect($(".govuk-back-link").attr("href")).toContain("/livestock/check-herd-details");
       expectPhaseBanner.ok($);
@@ -141,7 +141,7 @@ describe("select-the-herd tests", () => {
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
       expect($("title").text().trim()).toContain(
-        "Is this the same herd you have previously claimed for? - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
+        "Previous herd livestock claim - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
       );
       expect($(".govuk-back-link").attr("href")).toContain("/livestock/check-herd-details");
       expect($('.govuk-radios__input[value="yes"]').is(":checked")).toBeTruthy();

--- a/test/integration/narrow/routes/livestock/claim/select-the-herd.test.js
+++ b/test/integration/narrow/routes/livestock/claim/select-the-herd.test.js
@@ -108,7 +108,7 @@ describe("select-the-herd tests", () => {
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
       expect($("title").text().trim()).toContain(
-        "Is this the same flock you have previously claimed for? - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
+        "Is this the same livestock flock you have previously claimed for? - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
       );
       expect($(".govuk-back-link").attr("href")).toContain("/livestock/date-of-visit");
       expectPhaseBanner.ok($);
@@ -133,7 +133,7 @@ describe("select-the-herd tests", () => {
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
       expect($("title").text().trim()).toContain(
-        "Is this the same herd you have previously claimed for? - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
+        "Is this the same livestock herd you have previously claimed for? - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
       );
       expect($(".govuk-back-link").attr("href")).toContain("/livestock/date-of-visit");
       expect($('.govuk-radios__input[value="NEW_HERD"]').is(":checked")).toBeTruthy();
@@ -172,7 +172,7 @@ describe("select-the-herd tests", () => {
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
       expect($("title").text().trim()).toContain(
-        "Select the herd you are claiming for - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
+        "Livestock herd you are claiming for - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
       );
       expectPhaseBanner.ok($);
 
@@ -221,7 +221,7 @@ describe("select-the-herd tests", () => {
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
       expect($("title").text().trim()).toContain(
-        "Is this the same flock you have previously claimed for? - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
+        "Is this the same livestock flock you have previously claimed for? - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
       );
       expect($(".govuk-back-link").attr("href")).toContain("/livestock/date-of-visit");
       expectPhaseBanner.ok($);
@@ -296,7 +296,7 @@ describe("select-the-herd tests", () => {
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
       expect($("title").text().trim()).toContain(
-        "Select the herd you are claiming for - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
+        "Livestock herd you are claiming for - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
       );
       expectPhaseBanner.ok($);
 
@@ -384,7 +384,7 @@ describe("select-the-herd tests", () => {
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
       expect($("title").text().trim()).toContain(
-        "Select the herd you are claiming for - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
+        "Livestock herd you are claiming for - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
       );
       expectPhaseBanner.ok($);
 

--- a/test/integration/narrow/routes/livestock/claim/sheep-test-results.test.js
+++ b/test/integration/narrow/routes/livestock/claim/sheep-test-results.test.js
@@ -80,6 +80,8 @@ describe("Sheep test result tests", () => {
       const $ = cheerio.load(res.payload);
 
       expect(res.statusCode).toBe(200);
+      expect($("h1").text()).toMatch("What was the Sheep scab result?");
+      expect($("title").text()).toContain("Sheep livestock test result");
       expect($(".govuk-back-link").attr("href")).toContain(
         "/livestock/sheep-test-results?diseaseType=other",
       );

--- a/test/integration/narrow/routes/livestock/claim/sheep-tests.test.js
+++ b/test/integration/narrow/routes/livestock/claim/sheep-tests.test.js
@@ -80,7 +80,7 @@ describe("Test Results test", () => {
         "Which disease or condition did the vet take samples to test for?",
       );
       expect($("title").text()).toMatch(
-        "Which disease or condition did the vet take samples to test for? - Get funding to improve animal health and welfare",
+        "Sheep livestock disease or condition samples - Get funding to improve animal health and welfare",
       );
       expect($(".govuk-back-link").attr("href")).toContain("/livestock/sheep-endemics-package");
 
@@ -116,7 +116,7 @@ describe("Test Results test", () => {
         "Which disease or condition did the vet take samples to test for?",
       );
       expect($("title").text()).toMatch(
-        "Which disease or condition did the vet take samples to test for? - Get funding to improve animal health and welfare",
+        "Sheep livestock disease or condition samples - Get funding to improve animal health and welfare",
       );
       expect($("a").text()).toMatch("Select a disease or condition");
 

--- a/test/integration/narrow/routes/livestock/claim/species-numbers.test.js
+++ b/test/integration/narrow/routes/livestock/claim/species-numbers.test.js
@@ -122,7 +122,7 @@ describe("Species numbers page", () => {
           `Did you have 11 or more ${typeOfLivestock} cattle  on the date of the ${typeOfReview === "REVIEW" ? "review" : "follow-up"}?`,
         );
         expect($("title").text().trim()).toContain(
-          `Did you have 11 or more ${typeOfLivestock} cattle  on the date of the ${typeOfReview === "REVIEW" ? "review" : "follow-up"}? - Get funding to improve animal health and welfare`,
+          `Minimum number of livestock on date of ${typeOfReview === "REVIEW" ? "review" : "follow-up"}? - Get funding to improve animal health and welfare`,
         );
         expect($(".govuk-hint").text().trim()).toEqual(
           "You can find this on the summary the vet gave you.",
@@ -177,7 +177,7 @@ describe("Species numbers page", () => {
           `Did you have 11 or more ${typeOfLivestock} cattle  on the date of the ${typeOfReview === "REVIEW" ? "review" : "follow-up"}?`,
         );
         expect($("title").text().trim()).toContain(
-          `Did you have 11 or more ${typeOfLivestock} cattle  on the date of the ${typeOfReview === "REVIEW" ? "review" : "follow-up"}? - Get funding to improve animal health and welfare`,
+          `Minimum number of livestock on date of ${typeOfReview === "REVIEW" ? "review" : "follow-up"}? - Get funding to improve animal health and welfare`,
         );
         expect($(".govuk-hint").text().trim()).toEqual(
           "You can find this on the summary the vet gave you.",
@@ -219,7 +219,7 @@ describe("Species numbers page", () => {
           `Did you have 11 or more ${typeOfLivestock} cattle in this herd on the date of the ${typeOfReview === "REVIEW" ? "review" : "follow-up"}?`,
         );
         expect($("title").text().trim()).toContain(
-          `Did you have 11 or more ${typeOfLivestock} cattle in this herd on the date of the ${typeOfReview === "REVIEW" ? "review" : "follow-up"}? - Get funding to improve animal health and welfare`,
+          `Minimum number of livestock on date of ${typeOfReview === "REVIEW" ? "review" : "follow-up"}? - Get funding to improve animal health and welfare`,
         );
         expect($(".govuk-hint").text().trim()).toEqual(
           "You can find this on the summary the vet gave you.",
@@ -256,7 +256,7 @@ describe("Species numbers page", () => {
         "Did you have 21 or more sheep in this flock on the date of the review?",
       );
       expect($("title").text().trim()).toContain(
-        "Did you have 21 or more sheep in this flock on the date of the review? - Get funding to improve animal health and welfare",
+        "Minimum number of livestock on date of review? - Get funding to improve animal health and welfare",
       );
       expect($(".govuk-hint").text().trim()).toEqual(
         "You can find this on the summary the vet gave you.",

--- a/test/integration/narrow/routes/livestock/claim/test-results.test.js
+++ b/test/integration/narrow/routes/livestock/claim/test-results.test.js
@@ -80,7 +80,7 @@ describe("Test Results test", () => {
       const $ = cheerio.load(res.payload);
       expect($("h1").text()).toMatch(question);
       expect($("title").text()).toContain(
-        `${question} - Get funding to improve animal health and welfare`,
+        "Livestock test result - Get funding to improve animal health and welfare",
       );
 
       expectPhaseBanner.ok($);

--- a/test/integration/narrow/routes/livestock/claim/test-urn.test.js
+++ b/test/integration/narrow/routes/livestock/claim/test-urn.test.js
@@ -117,7 +117,7 @@ describe("Test URN GET", () => {
         const $ = cheerio.load(res.payload);
         expect($("h1").text()).toMatch(title);
         expect($("title").text()).toContain(
-          `${title} - Get funding to improve animal health and welfare`,
+          "Livestock laboratory's unique reference number - Get funding to improve animal health and welfare",
         );
 
         expectPhaseBanner.ok($);

--- a/test/integration/narrow/routes/livestock/claim/type-of-samples-taken.test.js
+++ b/test/integration/narrow/routes/livestock/claim/type-of-samples-taken.test.js
@@ -74,7 +74,7 @@ describe("Type of samples taken test", () => {
       const $ = cheerio.load(res.payload);
       expect($("h1").text()).toMatch("What type of samples were taken?");
       expect($("title").text()).toContain(
-        "What type of samples were taken? - Get funding to improve animal health and welfare",
+        "Type of livestock samples - Get funding to improve animal health and welfare",
       );
       expectPhaseBanner.ok($);
     });

--- a/test/integration/narrow/routes/livestock/claim/vaccination.test.js
+++ b/test/integration/narrow/routes/livestock/claim/vaccination.test.js
@@ -70,7 +70,7 @@ describe("Vaccination test", () => {
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
       expect($("title").text()).toContain(
-        "Herd Vaccination Status - Get funding to improve animal health and welfare",
+        "Livestock vaccination - Get funding to improve animal health and welfare",
       );
       expect($("h1").text()).toMatch(
         "What is the herd porcine reproductive and respiratory syndrome (PRRS) vaccination status?",

--- a/test/integration/narrow/routes/livestock/claim/vet-name.test.js
+++ b/test/integration/narrow/routes/livestock/claim/vet-name.test.js
@@ -91,7 +91,7 @@ describe("Vet name test", () => {
         const $ = cheerio.load(res.payload);
         expect($("h1").text()).toMatch("What is the vet's name?");
         expect($("title").text().trim()).toContain(
-          "What is the vet's name? - Get funding to improve animal health and welfare",
+          "Livestock vet's name - Get funding to improve animal health and welfare",
         );
         expectPhaseBanner.ok($);
       },

--- a/test/integration/narrow/routes/livestock/claim/vet-rcvs.test.js
+++ b/test/integration/narrow/routes/livestock/claim/vet-rcvs.test.js
@@ -82,7 +82,7 @@ describe("Vet rcvs test when Optional PI Hunt is OFF", () => {
         "What is the vet's Royal College of Veterinary Surgeons (RCVS) number?",
       );
       expect($("title").text().trim()).toContain(
-        "What is the vet's Royal College of Veterinary Surgeons (RCVS) number? - Get funding to improve animal health and welfare",
+        "Livestock vet's RCVS number - Get funding to improve animal health and welfare",
       );
       expectPhaseBanner.ok($);
     });

--- a/test/integration/narrow/routes/livestock/claim/vet-visits-review-test-results.test.js
+++ b/test/integration/narrow/routes/livestock/claim/vet-visits-review-test-results.test.js
@@ -75,7 +75,7 @@ describe("Test Results test", () => {
         "What was the test result of your last animal health and welfare review?",
       );
       expect($("title").text()).toContain(
-        "Vet Visits Review Test Results - Get funding to improve animal health and welfare",
+        "Livestock test results - Get funding to improve animal health and welfare",
       );
 
       expectPhaseBanner.ok($);

--- a/test/integration/narrow/routes/livestock/claim/which-species.test.js
+++ b/test/integration/narrow/routes/livestock/claim/which-species.test.js
@@ -89,7 +89,7 @@ describe("Endemics which species test", () => {
 
       expect(res.statusCode).toBe(200);
       expect($("title").text().trim()).toContain(
-        "Which species are you claiming for? - Get funding to improve animal health and welfare - GOV.UK",
+        "Which livestock species are you claiming for? - Get funding to improve animal health and welfare - GOV.UK",
       );
       expect($("h1").text().trim()).toMatch("Which species are you claiming for?");
       expect($(".govuk-radios__item").length).toEqual(4);

--- a/test/integration/narrow/routes/livestock/claim/which-type-of-review.test.js
+++ b/test/integration/narrow/routes/livestock/claim/which-type-of-review.test.js
@@ -94,7 +94,7 @@ describe("Which type of review test", () => {
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
       expect($("title").text().trim()).toContain(
-        "Are you claiming for a review or follow-up? - Get funding to improve animal health and welfare",
+        "Are you claiming for a livestock review or follow-up? - Get funding to improve animal health and welfare",
       );
       expect($(".govuk-back-link").attr("href")).toContain("/livestock/species");
       expectPhaseBanner.ok($);

--- a/test/integration/narrow/routes/livestock/vet-visits.test.js
+++ b/test/integration/narrow/routes/livestock/vet-visits.test.js
@@ -145,6 +145,10 @@ describe("GET /livestock/manage-claims", () => {
 
       const $ = cheerio.load(payload);
 
+      expect($("title").text()).toContain(
+        "Manage your livestock claims - Get funding to improve animal health and welfare",
+      );
+
       expect(findByText($, "Important").length).toBe(0);
 
       expect(getTableCells($)).toEqual([


### PR DESCRIPTION
## Summary
Updates the browser-tab `<title>` text on the Livestock Apply, Claim and dashboard screens so each one names the journey. Previously many Livestock screens shared an identical title with their Poultry twin, so the tab gave the farmer no clue which journey they were on. This is a titles-only change: no URLs, headings, on-page copy or behaviour change.

## What Changed
- Reworded the `<title>` on 44 Livestock screens to include "livestock" (or the relevant species word), per the approved title table.
- Kept every change inside each template's `pageTitle` block only - `<h1>` headings, fieldset legends, input labels, button aria-labels and body copy are untouched.
- Two screens needed a handler change because their title was built in JS from a variable shared with the visible heading; those now compute a separate title string so the heading is unaffected.
- On the select-herd screen, the tab title is now derived from the same source as the on-page heading, so the two can no longer diverge in the multiple-herds edge case.
- Updated the narrow integration tests to assert the new titles, and added title assertions on screens that previously had none, while pinning existing heading assertions to prove they did not change.

## Why
Distinct browser-tab titles help farmers stay oriented when both journeys are in play, and meet the GOV.UK "page titled" expectation. This is the content half of the Livestock alignment work, following the URL slug and folder-structure changes already merged.