### PR TITLE
refactor: (AHWR-2045) reconcile dev sign-in naming on dev-landing-page #patch

### DIFF
--- a/app/constants/routes.js
+++ b/app/constants/routes.js
@@ -25,7 +25,6 @@ export const loginRoutes = {
   signOut: "/sign-out",
   cannotSignIn: "/cannot-sign-in",
   devLandingPage: "/dev-landing-page",
-  devSignIn: "/dev-sign-in",
 };
 
 export const applyRoutes = {

--- a/app/plugins/redirect-agreement-redacted.js
+++ b/app/plugins/redirect-agreement-redacted.js
@@ -7,7 +7,6 @@ export const redirectAgreementRedactedPlugin = {
     register: (server, _) => {
       const excludedPaths = [
         loginRoutes.cannotSignIn,
-        loginRoutes.devSignIn,
         supportRoutes.health,
         supportRoutes.assets,
         applyRoutes.declaration,

--- a/app/plugins/redirect-no-check-details.js
+++ b/app/plugins/redirect-no-check-details.js
@@ -8,7 +8,6 @@ export const redirectNoCheckDetailsPlugin = {
       const excludedPaths = [
         loginRoutes.signIn,
         loginRoutes.devLandingPage,
-        loginRoutes.devSignIn,
         loginRoutes.signOut,
         loginRoutes.signInOidc,
         loginRoutes.cannotSignIn,

--- a/app/plugins/router.js
+++ b/app/plugins/router.js
@@ -6,7 +6,7 @@ import { updateDetailsHandlers } from "../routes/update-details.js";
 import { signinRouteHandlers } from "../routes/signin-oidc.js";
 import { downloadApplicationHandlers } from "../routes/download-application.js";
 import { vetVisitsHandlers } from "../routes/livestock/vet-visits.js";
-import { devLoginHandlers } from "../routes/dev-sign-in.js";
+import { devLoginHandlers } from "../routes/dev-landing-page.js";
 import { accessibilityRouteHandlers } from "../routes/accessibility.js";
 import { signOutHandlers } from "../routes/sign-out.js";
 import { config } from "../config/index.js";

--- a/app/routes/dev-landing-page.js
+++ b/app/routes/dev-landing-page.js
@@ -61,7 +61,7 @@ export const devLoginHandlers = [
     path: loginRoutes.devLandingPage,
     options: {
       auth: false,
-      handler: async (request, h) => {
+      handler: async (_request, h) => {
         // Removing this for now, some issues were seen in perf tests, but real user generating real MI report events won't go via here anyway
         // await clearAllOfSession(request);
         return h.view("dev-landing-page");

--- a/app/routes/dev-landing-page.js
+++ b/app/routes/dev-landing-page.js
@@ -15,8 +15,7 @@ import HttpStatus from "http-status-codes";
 import { RPA_CONTACT_DETAILS } from "ffc-ahwr-common-library";
 import { setSessionForErrorPage } from "./utils/check-login-valid.js";
 import { refreshApplications } from "../lib/context-helper.js";
-
-const devLandingPageUrl = "/dev-landing-page";
+import { loginRoutes } from "../constants/routes.js";
 
 const createDevDetails = (sbi) => {
   const organisationSummary = {
@@ -59,7 +58,7 @@ function throwErrorBasedOnSuffix(sbi = "") {
 export const devLoginHandlers = [
   {
     method: "GET",
-    path: devLandingPageUrl,
+    path: loginRoutes.devLandingPage,
     options: {
       auth: false,
       handler: async (request, h) => {
@@ -71,7 +70,7 @@ export const devLoginHandlers = [
   },
   {
     method: "POST",
-    path: devLandingPageUrl,
+    path: loginRoutes.devLandingPage,
     options: {
       auth: false,
       plugins: {
@@ -151,7 +150,7 @@ export const devLoginHandlers = [
 
           return h
             .view("verify-login-failed", {
-              backLink: devLandingPageUrl,
+              backLink: loginRoutes.devLandingPage,
               ruralPaymentsAgency: RPA_CONTACT_DETAILS,
               message: error.data?.payload?.message ?? error.message,
             })

--- a/test/integration/narrow/routes/dev-landing-page.test.js
+++ b/test/integration/narrow/routes/dev-landing-page.test.js
@@ -122,9 +122,13 @@ describe("Dev landing page test", () => {
     expect(res.headers.location).toEqual("/cannot-sign-in");
   });
 
-  test("POST dev sign-in route forwards to error page when forced to show CPH error", async () => {
+  test.each([
+    { scenario: "the business is locked", sbi: "123l" },
+    { scenario: "the person has invalid permissions", sbi: "123i" },
+    { scenario: "there is no eligible CPH", sbi: "123c" },
+    { scenario: "the sbi does not start with 1", sbi: "223456789l" },
+  ])("POST dev landing page forwards to cannot sign in when $scenario", async ({ sbi }) => {
     config.devLogin.enabled = true;
-    const sbi = "123c";
     const server = await createServer();
 
     refreshApplications.mockResolvedValueOnce({
@@ -139,51 +143,6 @@ describe("Dev landing page test", () => {
       },
       method: "POST",
       auth,
-    });
-
-    expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY);
-    expect(res.headers.location).toEqual("/cannot-sign-in");
-  });
-
-  test("POST dev sign-in route forwards to error page when forced to show Invalid permissions error", async () => {
-    config.devLogin.enabled = true;
-    const sbi = "123i";
-    const server = await createServer();
-
-    refreshApplications.mockResolvedValueOnce({
-      latestEndemicsApplication: undefined,
-      latestVetVisitApplication: undefined,
-    });
-
-    const res = await server.inject({
-      url: "/dev-landing-page",
-      payload: {
-        sbi,
-      },
-      method: "POST",
-      auth,
-    });
-
-    expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY);
-    expect(res.headers.location).toEqual("/cannot-sign-in");
-  });
-
-  test("POST dev sign-in route forwards to error page when forced to show locked business error", async () => {
-    config.devLogin.enabled = true;
-    const sbi = "123l";
-    const server = await createServer();
-
-    refreshApplications.mockResolvedValueOnce({
-      latestEndemicsApplication: undefined,
-      latestVetVisitApplication: undefined,
-    });
-
-    const res = await server.inject({
-      url: "/dev-landing-page",
-      payload: {
-        sbi,
-      },
-      method: "POST",
     });
 
     expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY);
@@ -200,29 +159,6 @@ describe("Dev landing page test", () => {
     });
 
     expect(res.statusCode).toBe(StatusCodes.OK);
-  });
-
-  test("POST dev landing page forwards to cannot sign in when the sbi does not start with 1", async () => {
-    config.devLogin.enabled = true;
-    const sbi = "223456789l";
-    const server = await createServer();
-
-    refreshApplications.mockResolvedValueOnce({
-      latestEndemicsApplication: undefined,
-      latestVetVisitApplication: undefined,
-    });
-
-    const res = await server.inject({
-      url: "/dev-landing-page",
-      payload: {
-        sbi,
-      },
-      method: "POST",
-      auth,
-    });
-
-    expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY);
-    expect(res.headers.location).toEqual("/cannot-sign-in");
   });
 
   test("POST dev landing page shows verify-login-failed for an unexpected error", async () => {

--- a/test/integration/narrow/routes/dev-landing-page.test.js
+++ b/test/integration/narrow/routes/dev-landing-page.test.js
@@ -13,7 +13,7 @@ jest.mock("../../../../app/lib/context-helper.js");
 
 const auth = { credentials: {}, strategy: "cookie" };
 
-describe("Dev sign in page test", () => {
+describe("Dev landing page test", () => {
   afterEach(() => {
     jest.resetAllMocks();
     jest.clearAllMocks();

--- a/test/integration/narrow/routes/dev-landing-page.test.js
+++ b/test/integration/narrow/routes/dev-landing-page.test.js
@@ -189,4 +189,101 @@ describe("Dev landing page test", () => {
     expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY);
     expect(res.headers.location).toEqual("/cannot-sign-in");
   });
+
+  test("GET dev landing page renders the sign-in view", async () => {
+    config.devLogin.enabled = true;
+    const server = await createServer();
+
+    const res = await server.inject({
+      url: "/dev-landing-page",
+      method: "GET",
+    });
+
+    expect(res.statusCode).toBe(StatusCodes.OK);
+  });
+
+  test("POST dev landing page forwards to cannot sign in when the sbi does not start with 1", async () => {
+    config.devLogin.enabled = true;
+    const sbi = "223456789l";
+    const server = await createServer();
+
+    refreshApplications.mockResolvedValueOnce({
+      latestEndemicsApplication: undefined,
+      latestVetVisitApplication: undefined,
+    });
+
+    const res = await server.inject({
+      url: "/dev-landing-page",
+      payload: {
+        sbi,
+      },
+      method: "POST",
+      auth,
+    });
+
+    expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY);
+    expect(res.headers.location).toEqual("/cannot-sign-in");
+  });
+
+  test("POST dev landing page shows verify-login-failed for an unexpected error", async () => {
+    config.devLogin.enabled = true;
+    const sbi = "123456789";
+    const server = await createServer();
+
+    refreshApplications.mockRejectedValueOnce(new Error("something went wrong"));
+
+    const res = await server.inject({
+      url: "/dev-landing-page",
+      payload: {
+        sbi,
+      },
+      method: "POST",
+      auth,
+    });
+
+    expect(res.statusCode).toBe(StatusCodes.BAD_REQUEST);
+    expect(res.payload).toContain("something went wrong");
+  });
+
+  test("POST dev landing page handles a missing sbi via the default", async () => {
+    config.devLogin.enabled = true;
+    const server = await createServer();
+
+    refreshApplications.mockResolvedValueOnce({
+      latestEndemicsApplication: undefined,
+      latestVetVisitApplication: undefined,
+    });
+
+    const res = await server.inject({
+      url: "/dev-landing-page",
+      payload: {},
+      method: "POST",
+      auth,
+    });
+
+    expect(res.statusCode).toBe(302);
+    expect(res.headers.location).toBe("/check-details");
+  });
+
+  test("POST dev landing page shows the payload message when the error carries one", async () => {
+    config.devLogin.enabled = true;
+    const sbi = "123456789";
+    const server = await createServer();
+
+    const error = new Error("fallback message");
+    error.data = { payload: { message: "specific payload message" } };
+    refreshApplications.mockRejectedValueOnce(error);
+
+    const res = await server.inject({
+      url: "/dev-landing-page",
+      payload: {
+        sbi,
+      },
+      method: "POST",
+      auth,
+    });
+
+    expect(res.statusCode).toBe(StatusCodes.BAD_REQUEST);
+    expect(res.payload).toContain("specific payload message");
+  });
 });


### PR DESCRIPTION
## Summary
Aligns the local dev sign-in tooling on a single, consistent name. The handler, its test, the route path, the view and the route constant now all reflect the live `dev-landing-page` name, and the stale `devSignIn` constant is gone.

Developer-only tooling, gated behind `DEV_LOGIN_ENABLED`; no production auth or user-facing behaviour is affected.

## What Changed
- Renamed the handler `app/routes/dev-sign-in.js` to `app/routes/dev-landing-page.js` and its co-located test to match, updating the router import.
- Replaced the handler's local `/dev-landing-page` literal with the shared `loginRoutes.devLandingPage` constant so the path has a single source of truth.
- Removed the dead `devSignIn` (`/dev-sign-in`) constant, which was backed by no route and matched no request path.
- Dropped the now-redundant `devSignIn` reference from the two redirect plugins that listed it; both removals are no-ops as the constant never matched a served path.

## Why
The area had a four-way naming inconsistency (file, path, view, constants) that made it confusing to navigate, plus a stale constant referenced by redirect plugins but backed by no handler. Reconciling the names on the live `dev-landing-page` and removing the dead reference makes the tooling easier to reason about with no change in behaviour.