### PR TITLE
test(livestock): (AHWR-2066) adopt shared title/heading helpers on apply screens #patch

### DIFF
--- a/test/integration/narrow/routes/livestock/apply/declaration.test.js
+++ b/test/integration/narrow/routes/livestock/apply/declaration.test.js
@@ -23,6 +23,7 @@ import {
   testBrowserPageTitle,
   testPageHeading,
 } from "../../../../../helpers/page-title-and-heading.js";
+import { testRedirectsToSignInWhenLoggedOut } from "../../../../../helpers/sign-in-redirect.js";
 
 jest.mock("../../../../../../app/lib/context-helper");
 jest.mock("../../../../../../app/session/index");
@@ -86,16 +87,8 @@ describe("Declaration test", () => {
   createApplication.mockResolvedValue({ applicationReference: "IAHW-PJ7E-WSI8" });
 
   describe("GET /livestock/agreement-offer route", () => {
-    test("when not logged in redirects to dashboard /sign-in", async () => {
-      const options = {
-        method: "GET",
-        url: "/livestock/agreement-offer",
-      };
-
-      const res = await server.inject(options);
-
-      expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY);
-      expect(res.headers.location.toString()).toEqual("/sign-in");
+    testRedirectsToSignInWhenLoggedOut({
+      getResponse: () => server.inject({ method: "GET", url: "/livestock/agreement-offer" }),
     });
 
     const getResponse = () =>

--- a/test/integration/narrow/routes/livestock/apply/declaration.test.js
+++ b/test/integration/narrow/routes/livestock/apply/declaration.test.js
@@ -19,6 +19,10 @@ import { when } from "jest-when";
 import { trackEvent } from "../../../../../../app/logging/logger.js";
 import { refreshApplications } from "../../../../../../app/lib/context-helper.js";
 import { axe } from "../../../../../helpers/axe-helper.js";
+import {
+  testBrowserPageTitle,
+  testPageHeading,
+} from "../../../../../helpers/page-title-and-heading.js";
 
 jest.mock("../../../../../../app/lib/context-helper");
 jest.mock("../../../../../../app/session/index");
@@ -94,22 +98,21 @@ describe("Declaration test", () => {
       expect(res.headers.location.toString()).toEqual("/sign-in");
     });
 
-    test("returns 200 when organisation found in session", async () => {
-      const options = {
-        method: "GET",
-        url: "/livestock/agreement-offer",
-        auth,
-      };
+    const getResponse = () =>
+      server.inject({ method: "GET", url: "/livestock/agreement-offer", auth });
 
-      const res = await server.inject(options);
+    testBrowserPageTitle({
+      title: "Review your livestock agreement offer",
+      getResponse,
+    });
+    testPageHeading({ heading: "Review your agreement offer", getResponse });
+
+    test("returns 200 when organisation found in session", async () => {
+      const res = await getResponse();
 
       expect(await axe(res.payload)).toHaveNoViolations();
       expect(res.statusCode).toBe(StatusCodes.OK);
       const $ = cheerio.load(res.payload);
-      expect($("h1").text()).toMatch("Review your agreement offer");
-      expect($("title").text()).toMatch(
-        "Review your livestock agreement offer - Get funding to improve animal health and welfare",
-      );
       ok($);
       const expectedHerdsText = `If the RPA requests evidence that your reviews or follow-ups took place, or details of the herd or flocks you have, you must provide it. This will be on your vet summary.`;
       const herdsText = $("p")

--- a/test/integration/narrow/routes/livestock/apply/numbers.test.js
+++ b/test/integration/narrow/routes/livestock/apply/numbers.test.js
@@ -12,6 +12,10 @@ import { applyRoutes } from "../../../../../../app/constants/routes.js";
 import { userType } from "../../../../../../app/constants/constants.js";
 import { when } from "jest-when";
 import { axe } from "../../../../../helpers/axe-helper.js";
+import {
+  testBrowserPageTitle,
+  testPageHeading,
+} from "../../../../../helpers/page-title-and-heading.js";
 
 jest.mock("../../../../../../app/api-requests/application-api");
 jest.mock("../../../../../../app/session/index.js");
@@ -60,24 +64,22 @@ describe("Check review numbers page test", () => {
   });
 
   describe("GET /livestock/minimum-number route when logged in", () => {
+    const getResponse = () => server.inject({ ...options, method: "GET" });
+
+    testBrowserPageTitle({ title: "Minimum number of livestock", getResponse });
+    testPageHeading({
+      heading: "Minimum number of each species in each herd or flock",
+      getResponse,
+    });
+
     test("returns 200 and has correct backLink", async () => {
-      const res = await server.inject({ ...options, method: "GET" });
+      const res = await getResponse();
 
       expect(await axe(res.payload)).toHaveNoViolations();
       expect(res.statusCode).toBe(200);
 
       const $ = cheerio.load(res.payload);
-      const titleClassName = ".govuk-heading-l";
-      const heading = "Minimum number of each species in each herd or flock";
-      const title = "Minimum number of livestock";
-      const pageTitleByClassName = $(titleClassName).text();
-      const pageTitleByName = $("title").text();
-      const fullTitle = `${title} - Get funding to improve animal health and welfare`;
-      const backLinkUrlByClassName = $(".govuk-back-link").attr("href");
-
-      expect(pageTitleByName).toContain(fullTitle);
-      expect(pageTitleByClassName).toEqual(heading);
-      expect(backLinkUrlByClassName).toContain(applyRoutes.youCanClaimMultiple);
+      expect($(".govuk-back-link").attr("href")).toContain(applyRoutes.youCanClaimMultiple);
       ok($);
     });
   });

--- a/test/integration/narrow/routes/livestock/apply/timings.test.js
+++ b/test/integration/narrow/routes/livestock/apply/timings.test.js
@@ -11,6 +11,10 @@ import { applyRoutes } from "../../../../../../app/constants/routes.js";
 import { userType } from "../../../../../../app/constants/constants.js";
 import { when } from "jest-when";
 import { axe } from "../../../../../helpers/axe-helper.js";
+import {
+  testBrowserPageTitle,
+  testPageHeading,
+} from "../../../../../helpers/page-title-and-heading.js";
 
 const auth = {
   credentials: { reference: "1111", sbi: "111111111" },
@@ -54,24 +58,45 @@ describe("Declaration test", () => {
   });
 
   describe("GET /livestock/timings route", () => {
-    test("returns 200 when application found", async () => {
+    const getOptions = {
+      method: "GET",
+      url: applyRoutes.timings,
+      auth,
+    };
+
+    beforeEach(() => {
+      when(getSessionData)
+        .calledWith(expect.anything(), sessionEntryKeys.application)
+        .mockReturnValue({ reference: "IAHW-1234-ABCD" });
+      when(getSessionData)
+        .calledWith(expect.anything(), sessionEntryKeys.organisation)
+        .mockReturnValue(organisation);
+      when(getSessionData)
+        .calledWith(
+          expect.anything(),
+          sessionEntryKeys.confirmedDetails,
+          sessionKeys.confirmedDetails,
+        )
+        .mockReturnValue(true);
+    });
+
+    const getResponse = () => {
       getApplicationsBySbi.mockResolvedValueOnce([]);
+      return server.inject(getOptions);
+    };
 
-      const options = {
-        method: "GET",
-        url: applyRoutes.timings,
-        auth,
-      };
+    testBrowserPageTitle({
+      title: "Timing of livestock reviews and follow-ups",
+      getResponse,
+    });
+    testPageHeading({ heading: "Timing of reviews and follow-ups", getResponse });
 
-      const res = await server.inject(options);
+    test("returns 200 when application found", async () => {
+      const res = await getResponse();
 
       expect(await axe(res.payload)).toHaveNoViolations();
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
-      expect($("h1").text()).toMatch("Timing of reviews and follow-ups");
-      expect($("title").text()).toMatch(
-        "Timing of livestock reviews and follow-ups - Get funding to improve animal health and welfare",
-      );
       expect($("main h2").length).toBe(2);
 
       const firstListItems = $("ul.govuk-list--bullet").first().find("li");

--- a/test/integration/narrow/routes/livestock/apply/you-can-claim-multiple.test.js
+++ b/test/integration/narrow/routes/livestock/apply/you-can-claim-multiple.test.js
@@ -12,6 +12,10 @@ import { applyRoutes } from "../../../../../../app/constants/routes.js";
 import { when } from "jest-when";
 import { userType } from "../../../../../../app/constants/constants.js";
 import { axe } from "../../../../../helpers/axe-helper.js";
+import {
+  testBrowserPageTitle,
+  testPageHeading,
+} from "../../../../../helpers/page-title-and-heading.js";
 
 jest.mock("../../../../../../app/config/index.js", () => ({
   config: {
@@ -67,15 +71,22 @@ describe("you-can-claim-multiple page", () => {
   });
 
   describe("GET operation handler", () => {
+    const getResponse = () => server.inject({ ...optionsBase, method: "GET" });
+
+    testBrowserPageTitle({
+      title: "What you can claim for a livestock agreement",
+      getResponse,
+    });
+    testPageHeading({
+      heading: "What you can claim for as part of this agreement",
+      getResponse,
+    });
+
     test("returns 200 and content is correct", async () => {
-      const res = await server.inject({ ...optionsBase, method: "GET" });
+      const res = await getResponse();
 
       expect(await axe(res.payload)).toHaveNoViolations();
       expect(res.statusCode).toBe(StatusCodes.OK);
-      expect(res.payload).toContain(
-        "What you can claim for a livestock agreement - Get funding to improve animal health and welfare",
-      );
-      expect(res.payload).toContain("What you can claim for as part of this agreement"); // h1 unchanged
       expect(res.payload).toContain("/check-details"); // back-link
       expect(setSessionData).toHaveBeenCalledWith(
         expect.anything(),

--- a/test/integration/narrow/routes/livestock/claim/assurance-scheme.test.js
+++ b/test/integration/narrow/routes/livestock/claim/assurance-scheme.test.js
@@ -14,6 +14,7 @@ import {
   testBrowserPageTitle,
   testPageHeading,
 } from "../../../../../helpers/page-title-and-heading.js";
+import { testRedirectsToSignInWhenLoggedOut } from "../../../../../helpers/sign-in-redirect.js";
 
 jest.mock("../../../../../../app/messaging/ineligibility-event-emission.js");
 jest.mock("../../../../../../app/session/index.js");
@@ -82,20 +83,8 @@ describe("Assurance Scheme", () => {
     });
     testPageHeading({ heading: "Is this flock part of an Assurance Scheme?", getResponse });
 
-    test("redirect if not logged in / authorized", async () => {
-      const options = {
-        method: "GET",
-        url,
-      };
-
-      when(getSessionData)
-        .calledWith(expect.anything(), sessionEntryKeys.endemicsClaim)
-        .mockReturnValue({ typeOfLivestock: "pigs" });
-
-      const response = await server.inject(options);
-
-      expect(response.statusCode).toBe(302);
-      expect(response.headers.location.toString()).toEqual(`/sign-in`);
+    testRedirectsToSignInWhenLoggedOut({
+      getResponse: () => server.inject({ method: "GET", url }),
     });
 
     test("Returns 200", async () => {

--- a/test/integration/narrow/routes/livestock/claim/assurance-scheme.test.js
+++ b/test/integration/narrow/routes/livestock/claim/assurance-scheme.test.js
@@ -10,6 +10,10 @@ import {
 
 import { when } from "jest-when";
 import { axe } from "../../../../../helpers/axe-helper.js";
+import {
+  testBrowserPageTitle,
+  testPageHeading,
+} from "../../../../../helpers/page-title-and-heading.js";
 
 jest.mock("../../../../../../app/messaging/ineligibility-event-emission.js");
 jest.mock("../../../../../../app/session/index.js");
@@ -65,6 +69,19 @@ describe("Assurance Scheme", () => {
   });
 
   describe(`GET ${url} route`, () => {
+    const getResponse = () => {
+      when(getSessionData)
+        .calledWith(expect.anything(), sessionEntryKeys.endemicsClaim)
+        .mockReturnValue({ typeOfLivestock: "pigs" });
+      return server.inject({ method: "GET", url, auth });
+    };
+
+    testBrowserPageTitle({
+      title: "Livestock biosecurity assessment",
+      getResponse,
+    });
+    testPageHeading({ heading: "Is this flock part of an Assurance Scheme?", getResponse });
+
     test("redirect if not logged in / authorized", async () => {
       const options = {
         method: "GET",
@@ -82,21 +99,10 @@ describe("Assurance Scheme", () => {
     });
 
     test("Returns 200", async () => {
-      const options = {
-        method: "GET",
-        url,
-        auth,
-      };
-
-      const response = await server.inject(options);
+      const response = await getResponse();
 
       expect(await axe(response.payload)).toHaveNoViolations();
       expect(response.statusCode).toBe(200);
-      const $ = cheerio.load(response.payload);
-      expect($("title").text().trim()).toContain(
-        "Livestock biosecurity assessment - Get funding to improve animal health and welfare",
-      );
-      expect($("h1").text().trim()).toBe("Is this flock part of an Assurance Scheme?");
     });
   });
 

--- a/test/integration/narrow/routes/livestock/claim/biosecurity.test.js
+++ b/test/integration/narrow/routes/livestock/claim/biosecurity.test.js
@@ -11,6 +11,10 @@ import { isVisitDateAfterPIHuntAndDairyGoLive } from "../../../../../../app/lib/
 import { sendInvalidDataEvent } from "../../../../../../app/messaging/ineligibility-event-emission.js";
 import { when } from "jest-when";
 import { axe } from "../../../../../helpers/axe-helper.js";
+import {
+  testBrowserPageTitle,
+  testPageHeading,
+} from "../../../../../helpers/page-title-and-heading.js";
 
 jest.mock("../../../../../../app/messaging/ineligibility-event-emission.js");
 jest.mock("../../../../../../app/session/index.js");
@@ -69,6 +73,19 @@ describe("Biosecurity test when Optional PI Hunt is OFF", () => {
   });
 
   describe(`GET ${url} route`, () => {
+    const getResponse = () => {
+      when(getSessionData)
+        .calledWith(expect.anything(), sessionEntryKeys.endemicsClaim)
+        .mockReturnValue({ typeOfLivestock: "pigs", reference: "TEMP-6GSE-PIR8" });
+      return server.inject({ method: "GET", url, auth });
+    };
+
+    testBrowserPageTitle({
+      title: "Livestock biosecurity assessment",
+      getResponse,
+    });
+    testPageHeading({ heading: "Did the vet do a biosecurity assessment?", getResponse });
+
     test("redirect if not logged in / authorized", async () => {
       const options = {
         method: "GET",
@@ -119,22 +136,6 @@ describe("Biosecurity test when Optional PI Hunt is OFF", () => {
 
       expect(await axe(response.payload)).toHaveNoViolations();
       expect(response.statusCode).toBe(200);
-    });
-    test("display question text", async () => {
-      const options = {
-        method: "GET",
-        url,
-        auth,
-      };
-
-      const response = await server.inject(options);
-
-      expect(await axe(response.payload)).toHaveNoViolations();
-      const $ = cheerio.load(response.payload);
-      expect($("title").text()).toMatch(
-        "Livestock biosecurity assessment - Get funding to improve animal health and welfare",
-      );
-      expect($("h1").text()).toMatch("Did the vet do a biosecurity assessment?");
     });
     test("select 'yes' when biosecurity is 'yes'", async () => {
       const options = {

--- a/test/integration/narrow/routes/livestock/claim/biosecurity.test.js
+++ b/test/integration/narrow/routes/livestock/claim/biosecurity.test.js
@@ -15,6 +15,7 @@ import {
   testBrowserPageTitle,
   testPageHeading,
 } from "../../../../../helpers/page-title-and-heading.js";
+import { testRedirectsToSignInWhenLoggedOut } from "../../../../../helpers/sign-in-redirect.js";
 
 jest.mock("../../../../../../app/messaging/ineligibility-event-emission.js");
 jest.mock("../../../../../../app/session/index.js");
@@ -86,20 +87,8 @@ describe("Biosecurity test when Optional PI Hunt is OFF", () => {
     });
     testPageHeading({ heading: "Did the vet do a biosecurity assessment?", getResponse });
 
-    test("redirect if not logged in / authorized", async () => {
-      const options = {
-        method: "GET",
-        url,
-      };
-
-      when(getSessionData)
-        .calledWith(expect.anything(), sessionEntryKeys.endemicsClaim)
-        .mockReturnValue({ typeOfLivestock: "pigs" });
-
-      const response = await server.inject(options);
-
-      expect(response.statusCode).toBe(302);
-      expect(response.headers.location.toString()).toEqual(`/sign-in`);
+    testRedirectsToSignInWhenLoggedOut({
+      getResponse: () => server.inject({ method: "GET", url }),
     });
     test("Returns 200", async () => {
       const options = {

--- a/test/integration/narrow/routes/livestock/claim/check-answers.test.js
+++ b/test/integration/narrow/routes/livestock/claim/check-answers.test.js
@@ -43,6 +43,7 @@ import {
   testBrowserPageTitle,
   testPageHeading,
 } from "../../../../../helpers/page-title-and-heading.js";
+import { testRedirectsToSignInWhenLoggedOut } from "../../../../../helpers/sign-in-redirect.js";
 
 jest.mock("../../../../../../app/session/index.js");
 jest.mock("../../../../../../app/lib/context-helper.js");
@@ -111,16 +112,8 @@ describe("Check answers test", () => {
     });
     testPageHeading({ heading: "Check your answers", getResponse });
 
-    test("when not logged in redirects to /sign-in", async () => {
-      const options = {
-        method: "GET",
-        url,
-      };
-
-      const res = await server.inject(options);
-
-      expect(res.statusCode).toBe(302);
-      expect(res.headers.location.toString()).toEqual("/sign-in");
+    testRedirectsToSignInWhenLoggedOut({
+      getResponse: () => server.inject({ method: "GET", url }),
     });
 
     test("shows fields for a review claim in the correct order for each species for beef", async () => {
@@ -1068,18 +1061,14 @@ describe("Check answers test", () => {
       );
     });
 
-    test("when not logged in redirects to /sign-in", async () => {
-      const options = {
-        method: "POST",
-        url,
-        payload: { crumb },
-        headers: { cookie: `crumb=${crumb}` },
-      };
-
-      const res = await server.inject(options);
-
-      expect(res.statusCode).toBe(302);
-      expect(res.headers.location.toString()).toEqual(`/sign-in`);
+    testRedirectsToSignInWhenLoggedOut({
+      getResponse: () =>
+        server.inject({
+          method: "POST",
+          url,
+          payload: { crumb },
+          headers: { cookie: `crumb=${crumb}` },
+        }),
     });
   });
 });

--- a/test/integration/narrow/routes/livestock/claim/check-answers.test.js
+++ b/test/integration/narrow/routes/livestock/claim/check-answers.test.js
@@ -652,11 +652,6 @@ describe("Check answers test", () => {
         expect(await axe(res.payload)).toHaveNoViolations();
         expect(res.statusCode).toBe(200);
         const $ = cheerio.load(res.payload);
-
-        expect($("h1").text()).toMatch("Check your answers");
-        expect($("title").text()).toMatch(
-          "Check your answers before submitting your livestock claim - Get funding to improve animal health and welfare",
-        );
         expect($(".govuk-summary-list__key").text()).toContain(content);
         expect($(".govuk-summary-list__value").text()).toContain("SpeciesNumbers");
         expect($(".govuk-back-link").attr("href")).toEqual(backLink);
@@ -693,11 +688,6 @@ describe("Check answers test", () => {
       expect(await axe(res.payload)).toHaveNoViolations();
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
-
-      expect($("h1").text()).toMatch("Check your answers");
-      expect($("title").text()).toMatch(
-        "Check your answers before submitting your livestock claim - Get funding to improve animal health and welfare",
-      );
       expect($(".govuk-summary-list__key").text()).not.toContain("Test results\n");
       expect($(".govuk-summary-list__value").text()).not.toContain("TestResults");
     });
@@ -742,11 +732,6 @@ describe("Check answers test", () => {
         expect(await axe(res.payload)).toHaveNoViolations();
         expect(res.statusCode).toBe(200);
         const $ = cheerio.load(res.payload);
-
-        expect($("h1").text()).toMatch("Check your answers");
-        expect($("title").text()).toMatch(
-          "Check your answers before submitting your livestock claim - Get funding to improve animal health and welfare",
-        );
         expect($(".govuk-summary-list__key").text()).toContain("Review test result");
         expect($(".govuk-summary-list__value").text()).toContain("VetVisitsReviewTestResults");
       },

--- a/test/integration/narrow/routes/livestock/claim/check-answers.test.js
+++ b/test/integration/narrow/routes/livestock/claim/check-answers.test.js
@@ -39,6 +39,10 @@ import { submitNewClaim } from "../../../../../../app/api-requests/claim-api.js"
 import { when } from "jest-when";
 import { trackEvent } from "../../../../../../app/logging/logger.js";
 import { axe } from "../../../../../helpers/axe-helper.js";
+import {
+  testBrowserPageTitle,
+  testPageHeading,
+} from "../../../../../helpers/page-title-and-heading.js";
 
 jest.mock("../../../../../../app/session/index.js");
 jest.mock("../../../../../../app/lib/context-helper.js");
@@ -91,6 +95,22 @@ describe("Check answers test", () => {
   });
 
   describe(`GET ${url} route`, () => {
+    const getResponse = () => {
+      when(getSessionData)
+        .calledWith(expect.anything(), sessionEntryKeys.endemicsClaim)
+        .mockReturnValue(dairyReviewClaim);
+      when(getSessionData)
+        .calledWith(expect.anything(), sessionEntryKeys.organisation)
+        .mockReturnValue({ name: "business name" });
+      return server.inject({ method: "GET", url, auth });
+    };
+
+    testBrowserPageTitle({
+      title: "Check your answers before submitting your livestock claim",
+      getResponse,
+    });
+    testPageHeading({ heading: "Check your answers", getResponse });
+
     test("when not logged in redirects to /sign-in", async () => {
       const options = {
         method: "GET",
@@ -153,10 +173,6 @@ describe("Check answers test", () => {
       expect(await axe(res.payload)).toHaveNoViolations();
       const $ = cheerio.load(res.payload);
 
-      expect($("h1").text()).toMatch("Check your answers");
-      expect($("title").text()).toMatch(
-        "Check your answers before submitting your livestock claim - Get funding to improve animal health and welfare",
-      );
       expect(res.statusCode).toBe(200);
 
       const rowKeys = getRowKeys($);

--- a/test/integration/narrow/routes/livestock/claim/check-herd-details.test.js
+++ b/test/integration/narrow/routes/livestock/claim/check-herd-details.test.js
@@ -11,6 +11,10 @@ import {
 import { getNextMultipleHerdsPage } from "../../../../../../app/lib/get-next-multiple-herds-page.js";
 import { when } from "jest-when";
 import { axe } from "../../../../../helpers/axe-helper.js";
+import {
+  testBrowserPageTitle,
+  testPageHeading,
+} from "../../../../../helpers/page-title-and-heading.js";
 
 jest.mock("../../../../../../app/session/index.js");
 jest.mock("../../../../../../app/lib/get-next-multiple-herds-page.js");
@@ -72,6 +76,42 @@ describe("/livestock/check-herd-details tests", () => {
   });
 
   describe("GET", () => {
+    const getResponse = (session) => () => {
+      when(getSessionData)
+        .calledWith(expect.anything(), sessionEntryKeys.endemicsClaim)
+        .mockReturnValue(session);
+      return server.inject({ method: "GET", url, auth });
+    };
+
+    const beefSession = {
+      reference: "TEMP-6GSE-PIR8",
+      typeOfReview: "REVIEW",
+      typeOfLivestock: "beef",
+      herdId: "909bb722-3de1-443e-8304-0bba8f922050",
+      herdVersion: 1,
+      herdName: "Commercial Herd",
+      herdCph: "22/333/4444",
+      isOnlyHerdOnSbi: "no",
+      herdReasons: ["differentBreed"],
+    };
+
+    testBrowserPageTitle({
+      title: "Check livestock herd details",
+      getResponse: getResponse(beefSession),
+    });
+    testBrowserPageTitle({
+      title: "Check livestock flock details",
+      getResponse: getResponse({ ...beefSession, typeOfLivestock: "sheep" }),
+    });
+    testPageHeading({
+      heading: "Check herd details",
+      getResponse: getResponse(beefSession),
+    });
+    testPageHeading({
+      heading: "Check flock details",
+      getResponse: getResponse({ ...beefSession, typeOfLivestock: "sheep" }),
+    });
+
     test("returns 200 with herd labels when species beef, also change links are correct", async () => {
       when(getSessionData)
         .calledWith(expect.anything(), sessionEntryKeys.endemicsClaim)
@@ -92,13 +132,9 @@ describe("/livestock/check-herd-details tests", () => {
       expect(await axe(res.payload)).toHaveNoViolations();
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
-      expect($("title").text().trim()).toContain(
-        "Check livestock herd details - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
-      );
       expect($(".govuk-back-link").attr("href")).toContain("/livestock/enter-herd-details");
       expect(assertLinkExistsFor($, "CPH number")).toBeTruthy();
       expect(assertLinkExistsFor($, "herd details")).toBeTruthy();
-      expect($("h1").text().trim()).toBe("Check herd details");
       expect(assertLinkExistsFor($, "Only herd associated with SBI")).toBeTruthy();
       expectPhaseBanner.ok($);
     });
@@ -123,14 +159,10 @@ describe("/livestock/check-herd-details tests", () => {
       expect(await axe(res.payload)).toHaveNoViolations();
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
-      expect($("title").text().trim()).toContain(
-        "Check livestock flock details - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
-      );
       expect($(".govuk-back-link").attr("href")).toContain("/livestock/enter-herd-details");
       expect(assertLinkExistsFor($, "CPH number")).toBeTruthy();
       expect(assertLinkExistsFor($, "flock details")).toBeTruthy();
       expect(assertLinkExistsFor($, "Only flock associated with SBI")).toBeTruthy();
-      expect($("h1").text().trim()).toBe("Check flock details");
       expectPhaseBanner.ok($);
     });
 
@@ -154,9 +186,6 @@ describe("/livestock/check-herd-details tests", () => {
       expect(await axe(res.payload)).toHaveNoViolations();
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
-      expect($("title").text().trim()).toContain(
-        "Check livestock herd details - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
-      );
       expect($(".govuk-back-link").attr("href")).toContain("/livestock/sbi-herds");
       expect(assertLinkExistsFor($, "CPH number")).toBeTruthy();
       expect(assertLinkExistsFor($, "Only herd associated with SBI")).toBeTruthy();
@@ -184,9 +213,6 @@ describe("/livestock/check-herd-details tests", () => {
       expect(await axe(res.payload)).toHaveNoViolations();
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
-      expect($("title").text().trim()).toContain(
-        "Check livestock herd details - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
-      );
       expect($(".govuk-back-link").attr("href")).toContain("/livestock/enter-herd-details");
       expect(assertLinkExistsFor($, "CPH number")).toBeTruthy();
       expect(assertLinkExistsFor($, "Only herd associated with SBI")).toBeTruthy();
@@ -220,13 +246,9 @@ describe("/livestock/check-herd-details tests", () => {
       expect(await axe(res.payload)).toHaveNoViolations();
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
-      expect($("title").text().trim()).toContain(
-        "Check livestock herd details - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
-      );
       expect($(".govuk-back-link").attr("href")).toContain("/livestock/enter-herd-details");
       expect(assertLinkExistsFor($, "CPH number")).toBeTruthy();
       expect(assertLinkExistsFor($, "herd details")).toBeTruthy();
-      expect($("h1").text().trim()).toBe("Check herd details");
       expect(assertLinkExistsFor($, "Only herd associated with SBI")).toBeTruthy();
       expectPhaseBanner.ok($);
     });
@@ -252,13 +274,9 @@ describe("/livestock/check-herd-details tests", () => {
       expect(await axe(res.payload)).toHaveNoViolations();
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
-      expect($("title").text().trim()).toContain(
-        "Check livestock herd details - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
-      );
       expect($(".govuk-back-link").attr("href")).toContain("/livestock/enter-herd-details");
       expect(assertLinkExistsFor($, "CPH number")).toBeTruthy();
       expect(assertLinkExistsFor($, "herd details")).toBeTruthy();
-      expect($("h1").text().trim()).toBe("Check herd details");
       expect(assertLinkExistsFor($, "Only herd associated with SBI")).toBeTruthy();
       expectPhaseBanner.ok($);
     });
@@ -288,13 +306,9 @@ describe("/livestock/check-herd-details tests", () => {
       expect(await axe(res.payload)).toHaveNoViolations();
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
-      expect($("title").text().trim()).toContain(
-        "Check livestock herd details - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
-      );
       expect($(".govuk-back-link").attr("href")).toContain("/livestock/enter-herd-details");
       expect(assertLinkExistsFor($, "CPH number")).toBeTruthy();
       expect(assertLinkExistsFor($, "herd details")).toBeTruthy();
-      expect($("h1").text().trim()).toBe("Check herd details");
       expect(assertLinkExistsFor($, "Only herd associated with SBI")).toBeFalsy();
       expectPhaseBanner.ok($);
     });

--- a/test/integration/narrow/routes/livestock/claim/confirmation.test.js
+++ b/test/integration/narrow/routes/livestock/claim/confirmation.test.js
@@ -8,6 +8,10 @@ import {
   sessionKeys,
 } from "../../../../../../app/session/index.js";
 import { when } from "jest-when";
+import {
+  testBrowserPageTitle,
+  testPageHeading,
+} from "../../../../../helpers/page-title-and-heading.js";
 
 jest.mock("../../../../../../app/session");
 
@@ -31,6 +35,48 @@ describe("Claim confirmation", () => {
     jest.clearAllMocks();
   });
 
+  const setupSession = (typeOfReview) => {
+    when(getSessionData)
+      .calledWith(expect.anything(), sessionEntryKeys.endemicsClaim)
+      .mockReturnValue({
+        reference,
+        amount: 55,
+        typeOfReview,
+      });
+
+    when(getSessionData)
+      .calledWith(
+        expect.anything(),
+        sessionEntryKeys.endemicsClaim,
+        sessionKeys.endemicsClaim.latestEndemicsApplication,
+      )
+      .mockReturnValue({ status: "AGREED" });
+
+    when(getSessionData)
+      .calledWith(
+        expect.anything(),
+        sessionEntryKeys.confirmedDetails,
+        sessionKeys.confirmedDetails,
+      )
+      .mockReturnValue(true);
+
+    when(getSessionData)
+      .calledWith(
+        expect.anything(),
+        sessionEntryKeys.endemicsClaim,
+        sessionKeys.endemicsClaim.reference,
+      )
+      .mockReturnValue("IAHW-1LZ5-ELVQ");
+  };
+
+  const getResponse = () => {
+    setupSession("REVIEW");
+    return server.inject({ method: "GET", url, auth });
+  };
+
+  testBrowserPageTitle({ title: "Livestock claim submitted", getResponse });
+  testPageHeading({ heading: "Claim complete", getResponse });
+
   test.each([{ typeOfReview: "FOLLOW_UP" }, { typeOfReview: "REVIEW" }])(
     "GET endemicsConfirmation route %s",
     async ({ typeOfReview }) => {
@@ -41,37 +87,7 @@ describe("Claim confirmation", () => {
         auth,
       };
 
-      when(getSessionData)
-        .calledWith(expect.anything(), sessionEntryKeys.endemicsClaim)
-        .mockReturnValue({
-          reference,
-          amount: 55,
-          typeOfReview,
-        });
-
-      when(getSessionData)
-        .calledWith(
-          expect.anything(),
-          sessionEntryKeys.endemicsClaim,
-          sessionKeys.endemicsClaim.latestEndemicsApplication,
-        )
-        .mockReturnValue({ status: "AGREED" });
-
-      when(getSessionData)
-        .calledWith(
-          expect.anything(),
-          sessionEntryKeys.confirmedDetails,
-          sessionKeys.confirmedDetails,
-        )
-        .mockReturnValue(true);
-
-      when(getSessionData)
-        .calledWith(
-          expect.anything(),
-          sessionEntryKeys.endemicsClaim,
-          sessionKeys.endemicsClaim.reference,
-        )
-        .mockReturnValue("IAHW-1LZ5-ELVQ");
+      setupSession(typeOfReview);
 
       const res = await server.inject(options);
 
@@ -80,10 +96,6 @@ describe("Claim confirmation", () => {
       const $ = cheerio.load(res.payload);
 
       expect(res.statusCode).toBe(200);
-      expect($("h1").text()).toContain("Claim complete");
-      expect($("title").text()).toContain(
-        "Livestock claim submitted - Get funding to improve animal health and welfare",
-      );
       expect($("#amount").text()).toContain("55");
       expect($("#reference").text().trim()).toEqual(reference);
       expect($("#message").text().trim()).toContain(

--- a/test/integration/narrow/routes/livestock/claim/date-of-testing.test.js
+++ b/test/integration/narrow/routes/livestock/claim/date-of-testing.test.js
@@ -21,6 +21,7 @@ import {
   testBrowserPageTitle,
   testPageHeading,
 } from "../../../../../helpers/page-title-and-heading.js";
+import { testRedirectsToSignInWhenLoggedOut } from "../../../../../helpers/sign-in-redirect.js";
 
 jest.mock("../../../../../../app/messaging/ineligibility-event-emission.js");
 jest.mock("../../../../../../app/session");
@@ -216,10 +217,8 @@ describe("Date of testing", () => {
       expect($("#on-another-date-year").val()).toBe("2024");
     });
 
-    test("redirects to /sign-in when not authenticated", async () => {
-      const res = await server.inject({ method: "GET", url });
-      expect(res.statusCode).toBe(302);
-      expect(res.headers.location).toBe("/sign-in");
+    testRedirectsToSignInWhenLoggedOut({
+      getResponse: () => server.inject({ method: "GET", url }),
     });
   });
 
@@ -228,10 +227,8 @@ describe("Date of testing", () => {
       crumb = await getCrumbs(server);
     });
 
-    test("redirects to /sign-in when not authenticated", async () => {
-      const res = await server.inject({ method: "POST", url });
-      expect(res.statusCode).toBe(302);
-      expect(res.headers.location).toBe("/sign-in");
+    testRedirectsToSignInWhenLoggedOut({
+      getResponse: () => server.inject({ method: "POST", url }),
     });
 
     test("returns 403 when CSRF crumb is missing", async () => {

--- a/test/integration/narrow/routes/livestock/claim/date-of-testing.test.js
+++ b/test/integration/narrow/routes/livestock/claim/date-of-testing.test.js
@@ -17,6 +17,10 @@ import {
 import { sendInvalidDataEvent } from "../../../../../../app/messaging/ineligibility-event-emission.js";
 import { when } from "jest-when";
 import { axe } from "../../../../../helpers/axe-helper.js";
+import {
+  testBrowserPageTitle,
+  testPageHeading,
+} from "../../../../../helpers/page-title-and-heading.js";
 
 jest.mock("../../../../../../app/messaging/ineligibility-event-emission.js");
 jest.mock("../../../../../../app/session");
@@ -88,6 +92,28 @@ describe("Date of testing", () => {
   });
 
   describe(`GET ${url} route`, () => {
+    const getResponse = () => {
+      when(getSessionData)
+        .calledWith(expect.anything(), sessionEntryKeys.endemicsClaim)
+        .mockReturnValue({
+          typeOfReview: "FOLLOW_UP",
+          typeOfLivestock: "beef",
+          latestEndemicsApplication,
+          reference: "TEMP-6GSE-PIR8",
+          dateOfVisit: "2022-01-01",
+        });
+      return server.inject({ method: "GET", url, auth });
+    };
+
+    testBrowserPageTitle({
+      title: "When livestock samples were taken",
+      getResponse,
+    });
+    testPageHeading({
+      heading: "When were samples taken?",
+      getResponse,
+    });
+
     test.each([{ typeOfLivestock: "beef" }, { typeOfLivestock: "dairy" }])(
       "returns 200",
       async ({ typeOfLivestock }) => {
@@ -112,10 +138,6 @@ describe("Date of testing", () => {
         expect(await axe(res.payload)).toHaveNoViolations();
         expect(res.statusCode).toBe(HttpStatus.OK);
         const $ = cheerio.load(res.payload);
-        expect($("h1").text()).toMatch("When were samples taken?");
-        expect($("title").text()).toContain(
-          "When livestock samples were taken - Get funding to improve animal health and welfare",
-        );
         expect($(".govuk-back-link").attr("href")).toMatch("/livestock/pi-hunt-all-animals");
         expectPhaseBanner.ok($);
         expect($("#whenTestingWasCarriedOut-hint").text()).toMatch(

--- a/test/integration/narrow/routes/livestock/claim/date-of-visit.test.js
+++ b/test/integration/narrow/routes/livestock/claim/date-of-visit.test.js
@@ -14,6 +14,10 @@ import { when } from "jest-when";
 import { sendInvalidDataEvent } from "../../../../../../app/messaging/ineligibility-event-emission.js";
 import { trackEvent } from "../../../../../../app/logging/logger.js";
 import { axe } from "../../../../../helpers/axe-helper.js";
+import {
+  testBrowserPageTitle,
+  testPageHeading,
+} from "../../../../../helpers/page-title-and-heading.js";
 
 jest.mock("../../../../../../app/session");
 jest.mock("../../../../../../app/messaging/ineligibility-event-emission.js");
@@ -105,6 +109,31 @@ describe("GET /livestock/date-of-visit handler", () => {
     await server.stop();
     jest.resetAllMocks();
   });
+
+  const getResponse = (typeOfReview) => () => {
+    when(getSessionData)
+      .calledWith(expect.anything(), sessionEntryKeys.endemicsClaim)
+      .mockReturnValue({
+        latestEndemicsApplication,
+        latestVetVisitApplication,
+        typeOfReview,
+        typeOfLivestock: "beef",
+        previousClaims: [],
+        reference: "TEMP-6GSE-PIR8",
+      });
+    return server.inject({ method: "GET", url, auth });
+  };
+
+  testBrowserPageTitle({
+    title: "Date of livestock review",
+    getResponse: getResponse("REVIEW"),
+  });
+  testBrowserPageTitle({
+    title: "Date of livestock follow-up",
+    getResponse: getResponse("FOLLOW_UP"),
+  });
+  testPageHeading({ heading: "Date of review", getResponse: getResponse("REVIEW") });
+  testPageHeading({ heading: "Date of follow-up", getResponse: getResponse("FOLLOW_UP") });
 
   test("returns 200 when you dont have any previous claims", async () => {
     when(getSessionData)
@@ -222,8 +251,6 @@ describe("GET /livestock/date-of-visit handler", () => {
     expect(await axe(res.payload)).toHaveNoViolations();
     expect(res.statusCode).toBe(200);
     const $ = cheerio.load(res.payload);
-    expect($("h1").text().trim()).toBe("Date of follow-up");
-    expect($("title").text()).toMatch(/^Date of livestock follow-up - /);
     expect($(".govuk-back-link").attr("href")).toBe("/livestock/vet-visits-review-test-results");
     expectPhaseBanner.ok($);
   });
@@ -250,8 +277,6 @@ describe("GET /livestock/date-of-visit handler", () => {
     expect(await axe(res.payload)).toHaveNoViolations();
     expect(res.statusCode).toBe(200);
     const $ = cheerio.load(res.payload);
-    expect($("h1").text().trim()).toBe("Date of review");
-    expect($("title").text()).toMatch(/^Date of livestock review - /);
     expect($(".govuk-back-link").attr("href")).toBe("/livestock/review-type");
     expectPhaseBanner.ok($);
   });

--- a/test/integration/narrow/routes/livestock/claim/date-of-visit.test.js
+++ b/test/integration/narrow/routes/livestock/claim/date-of-visit.test.js
@@ -18,6 +18,7 @@ import {
   testBrowserPageTitle,
   testPageHeading,
 } from "../../../../../helpers/page-title-and-heading.js";
+import { testRedirectsToSignInWhenLoggedOut } from "../../../../../helpers/sign-in-redirect.js";
 
 jest.mock("../../../../../../app/session");
 jest.mock("../../../../../../app/messaging/ineligibility-event-emission.js");
@@ -281,16 +282,8 @@ describe("GET /livestock/date-of-visit handler", () => {
     expectPhaseBanner.ok($);
   });
 
-  test("when not logged in redirects to /sign-in", async () => {
-    const options = {
-      method: "GET",
-      url,
-    };
-
-    const res = await server.inject(options);
-
-    expect(res.statusCode).toBe(302);
-    expect(res.headers.location.toString()).toEqual(`/sign-in`);
+  testRedirectsToSignInWhenLoggedOut({
+    getResponse: () => server.inject({ method: "GET", url }),
   });
 });
 
@@ -314,10 +307,8 @@ describe("POST /livestock/date-of-visit handler", () => {
     jest.clearAllMocks();
   });
 
-  test("redirects to /sign-in when not authenticated", async () => {
-    const res = await server.inject({ method: "POST", url });
-    expect(res.statusCode).toBe(302);
-    expect(res.headers.location).toBe("/sign-in");
+  testRedirectsToSignInWhenLoggedOut({
+    getResponse: () => server.inject({ method: "POST", url }),
   });
 
   test("returns 403 when CSRF crumb is missing", async () => {

--- a/test/integration/narrow/routes/livestock/claim/disease-status.test.js
+++ b/test/integration/narrow/routes/livestock/claim/disease-status.test.js
@@ -12,6 +12,7 @@ import {
   testBrowserPageTitle,
   testPageHeading,
 } from "../../../../../helpers/page-title-and-heading.js";
+import { testRedirectsToSignInWhenLoggedOut } from "../../../../../helpers/sign-in-redirect.js";
 
 jest.mock("../../../../../../app/session/index.js");
 
@@ -74,16 +75,8 @@ describe("Disease status test", () => {
     testBrowserPageTitle({ title: "Livestock disease status", getResponse });
     testPageHeading({ heading: "What is the disease status category?", getResponse });
 
-    test("redirect if not logged in / authorized", async () => {
-      const options = {
-        method: "GET",
-        url,
-      };
-
-      const response = await server.inject(options);
-
-      expect(response.statusCode).toBe(302);
-      expect(response.headers.location.toString()).toEqual(`/sign-in`);
+    testRedirectsToSignInWhenLoggedOut({
+      getResponse: () => server.inject({ method: "GET", url }),
     });
 
     test("Returns 200", async () => {

--- a/test/integration/narrow/routes/livestock/claim/disease-status.test.js
+++ b/test/integration/narrow/routes/livestock/claim/disease-status.test.js
@@ -8,6 +8,10 @@ import {
 } from "../../../../../../app/session/index.js";
 import { when } from "jest-when";
 import { axe } from "../../../../../helpers/axe-helper.js";
+import {
+  testBrowserPageTitle,
+  testPageHeading,
+} from "../../../../../helpers/page-title-and-heading.js";
 
 jest.mock("../../../../../../app/session/index.js");
 
@@ -60,6 +64,16 @@ describe("Disease status test", () => {
   });
 
   describe(`GET ${url}`, () => {
+    const getResponse = () => {
+      when(getSessionData)
+        .calledWith(expect.anything(), sessionEntryKeys.endemicsClaim)
+        .mockReturnValue({ reference: "TEMP-6GSE-PIR8" });
+      return server.inject({ method: "GET", url, auth });
+    };
+
+    testBrowserPageTitle({ title: "Livestock disease status", getResponse });
+    testPageHeading({ heading: "What is the disease status category?", getResponse });
+
     test("redirect if not logged in / authorized", async () => {
       const options = {
         method: "GET",
@@ -86,26 +100,6 @@ describe("Disease status test", () => {
 
       expect(await axe(response.payload)).toHaveNoViolations();
       expect(response.statusCode).toBe(200);
-    });
-
-    test("display question text", async () => {
-      const options = {
-        method: "GET",
-        url,
-        auth,
-      };
-      when(getSessionData)
-        .calledWith(expect.anything(), sessionEntryKeys.endemicsClaim)
-        .mockReturnValue({ reference: "TEMP-6GSE-PIR8" });
-
-      const response = await server.inject(options);
-
-      expect(await axe(response.payload)).toHaveNoViolations();
-      const $ = cheerio.load(response.payload);
-      expect($("h1").text()).toMatch("What is the disease status category?");
-      expect($("title").text()).toContain(
-        "Livestock disease status - Get funding to improve animal health and welfare",
-      );
     });
 
     test("select '1' when diseaseStatus is '1'", async () => {

--- a/test/integration/narrow/routes/livestock/claim/endemics-package.test.js
+++ b/test/integration/narrow/routes/livestock/claim/endemics-package.test.js
@@ -9,6 +9,10 @@ import expectPhaseBanner from "assert";
 import { getCrumbs } from "../../../../../utils/get-crumbs.js";
 import { when } from "jest-when";
 import { axe } from "../../../../../helpers/axe-helper.js";
+import {
+  testBrowserPageTitle,
+  testPageHeading,
+} from "../../../../../helpers/page-title-and-heading.js";
 
 jest.mock("../../../../../../app/session/index.js");
 
@@ -57,22 +61,17 @@ describe("Endemics package test", () => {
   });
 
   describe(`GET ${url} route`, () => {
-    test("Returns 200", async () => {
-      const options = {
-        method: "GET",
-        url,
-        auth,
-      };
+    const getResponse = () => server.inject({ method: "GET", url, auth });
 
-      const res = await server.inject(options);
+    testBrowserPageTitle({ title: "Sheep livestock health package", getResponse });
+    testPageHeading({ heading: "Which sheep health package did you choose?", getResponse });
+
+    test("Returns 200", async () => {
+      const res = await getResponse();
 
       expect(await axe(res.payload)).toHaveNoViolations();
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
-      expect($("h1").text().trim()).toMatch("Which sheep health package did you choose?");
-      expect($("title").text()).toContain(
-        "Sheep livestock health package - Get funding to improve animal health and welfare",
-      );
 
       expectPhaseBanner.ok($);
     });

--- a/test/integration/narrow/routes/livestock/claim/endemics-package.test.js
+++ b/test/integration/narrow/routes/livestock/claim/endemics-package.test.js
@@ -13,6 +13,7 @@ import {
   testBrowserPageTitle,
   testPageHeading,
 } from "../../../../../helpers/page-title-and-heading.js";
+import { testRedirectsToSignInWhenLoggedOut } from "../../../../../helpers/sign-in-redirect.js";
 
 jest.mock("../../../../../../app/session/index.js");
 
@@ -76,16 +77,8 @@ describe("Endemics package test", () => {
       expectPhaseBanner.ok($);
     });
 
-    test("when not logged in redirects to /sign-in", async () => {
-      const options = {
-        method: "GET",
-        url,
-      };
-
-      const res = await server.inject(options);
-
-      expect(res.statusCode).toBe(302);
-      expect(res.headers.location.toString()).toEqual(`/sign-in`);
+    testRedirectsToSignInWhenLoggedOut({
+      getResponse: () => server.inject({ method: "GET", url }),
     });
 
     test("backlink", async () => {
@@ -108,18 +101,14 @@ describe("Endemics package test", () => {
       crumb = await getCrumbs(server);
     });
 
-    test("when not logged in redirects to /sign-in", async () => {
-      const options = {
-        method: "POST",
-        url,
-        payload: { crumb, herdVaccinationStatus: "vaccinated" },
-        headers: { cookie: `crumb=${crumb}` },
-      };
-
-      const res = await server.inject(options);
-
-      expect(res.statusCode).toBe(302);
-      expect(res.headers.location.toString()).toEqual(`/sign-in`);
+    testRedirectsToSignInWhenLoggedOut({
+      getResponse: () =>
+        server.inject({
+          method: "POST",
+          url,
+          payload: { crumb, herdVaccinationStatus: "vaccinated" },
+          headers: { cookie: `crumb=${crumb}` },
+        }),
     });
 
     test.each([

--- a/test/integration/narrow/routes/livestock/claim/enter-cph-number.test.js
+++ b/test/integration/narrow/routes/livestock/claim/enter-cph-number.test.js
@@ -11,6 +11,10 @@ import {
 } from "../../../../../../app/session/index.js";
 import { when } from "jest-when";
 import { axe } from "../../../../../helpers/axe-helper.js";
+import {
+  testBrowserPageTitle,
+  testPageHeading,
+} from "../../../../../helpers/page-title-and-heading.js";
 
 jest.mock("../../../../../../app/session/index.js");
 
@@ -64,26 +68,46 @@ describe("/livestock/cph tests", () => {
   });
 
   const expectHerdText = ($) => {
-    expect($("title").text().trim()).toContain(
-      "CPH number for livestock - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
-    );
-    expect($(".govuk-heading-l").text().trim()).toBe(
-      "Enter the County Parish Holding (CPH) number for this herd",
-    );
     expect($(".govuk-label--m").text().trim()).toBe("CPH number for this herd");
   };
 
   const expectFlockText = ($) => {
-    expect($("title").text().trim()).toContain(
-      "CPH number for livestock - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
-    );
-    expect($(".govuk-heading-l").text().trim()).toBe(
-      "Enter the County Parish Holding (CPH) number for this flock",
-    );
     expect($(".govuk-label--m").text().trim()).toBe("CPH number for this flock");
   };
 
   describe("GET", () => {
+    const getResponse = (session) => () => {
+      when(getSessionData)
+        .calledWith(expect.anything(), sessionEntryKeys.endemicsClaim)
+        .mockReturnValue(session);
+      return server.inject({ method: "GET", url, auth });
+    };
+
+    testBrowserPageTitle({
+      title: "CPH number for livestock",
+      getResponse: getResponse({
+        reference: "TEMP-6GSE-PIR8",
+        typeOfReview: "REVIEW",
+        typeOfLivestock: "beef",
+      }),
+    });
+    testPageHeading({
+      heading: "Enter the County Parish Holding (CPH) number for this herd",
+      getResponse: getResponse({
+        reference: "TEMP-6GSE-PIR8",
+        typeOfReview: "REVIEW",
+        typeOfLivestock: "beef",
+      }),
+    });
+    testPageHeading({
+      heading: "Enter the County Parish Holding (CPH) number for this flock",
+      getResponse: getResponse({
+        reference: "TEMP-6GSE-PIR8",
+        typeOfReview: "REVIEW",
+        typeOfLivestock: "sheep",
+      }),
+    });
+
     test("returns 200 with herd labels when species beef", async () => {
       when(getSessionData)
         .calledWith(expect.anything(), sessionEntryKeys.endemicsClaim)

--- a/test/integration/narrow/routes/livestock/claim/enter-herd-details.test.js
+++ b/test/integration/narrow/routes/livestock/claim/enter-herd-details.test.js
@@ -12,6 +12,10 @@ import {
 import { ONLY_HERD } from "../../../../../../app/constants/claim-constants.js";
 import { when } from "jest-when";
 import { axe } from "../../../../../helpers/axe-helper.js";
+import {
+  testBrowserPageTitle,
+  testPageHeading,
+} from "../../../../../helpers/page-title-and-heading.js";
 
 jest.mock("../../../../../../app/session/index.js");
 
@@ -65,6 +69,46 @@ describe("/livestock/enter-herd-details tests", () => {
   });
 
   describe("GET", () => {
+    const getResponse = (session) => () => {
+      when(getSessionData)
+        .calledWith(expect.anything(), sessionEntryKeys.endemicsClaim)
+        .mockReturnValue(session);
+      return server.inject({ method: "GET", url, auth });
+    };
+
+    testBrowserPageTitle({
+      title: "Livestock herd details",
+      getResponse: getResponse({
+        reference: "TEMP-6GSE-PIR8",
+        typeOfReview: "REVIEW",
+        typeOfLivestock: "beef",
+      }),
+    });
+    testBrowserPageTitle({
+      title: "Livestock flock details",
+      getResponse: getResponse({
+        reference: "TEMP-6GSE-PIR8",
+        typeOfReview: "REVIEW",
+        typeOfLivestock: "sheep",
+      }),
+    });
+    testPageHeading({
+      heading: "Enter the herd details",
+      getResponse: getResponse({
+        reference: "TEMP-6GSE-PIR8",
+        typeOfReview: "REVIEW",
+        typeOfLivestock: "beef",
+      }),
+    });
+    testPageHeading({
+      heading: "Enter the flock details",
+      getResponse: getResponse({
+        reference: "TEMP-6GSE-PIR8",
+        typeOfReview: "REVIEW",
+        typeOfLivestock: "sheep",
+      }),
+    });
+
     test("returns 200 with herd labels when species beef", async () => {
       when(getSessionData)
         .calledWith(expect.anything(), sessionEntryKeys.endemicsClaim)
@@ -79,11 +123,7 @@ describe("/livestock/enter-herd-details tests", () => {
       expect(await axe(res.payload)).toHaveNoViolations();
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
-      expect($("title").text().trim()).toContain(
-        "Livestock herd details - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
-      );
       expect($(".govuk-back-link").attr("href")).toContain("/livestock/sbi-herds");
-      expect($(".govuk-heading-l").text().trim()).toBe("Enter the herd details");
       expect($(".govuk-hint").text().trim()).toContain("Tell us about this herd");
       const legendText = $(".govuk-fieldset__legend--m").text().trim();
       expect(legendText).toBe(
@@ -119,9 +159,6 @@ describe("/livestock/enter-herd-details tests", () => {
       expect(await axe(res.payload)).toHaveNoViolations();
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
-      expect($("title").text().trim()).toContain(
-        "Livestock herd details - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
-      );
       expect($(".govuk-back-link").attr("href")).toContain("/livestock/sbi-herds");
       expect($('.govuk-checkboxes__input[value="differentBreed"]').is(":checked")).toBeTruthy();
       expect($('.govuk-checkboxes__input[value="keptSeparate"]').is(":checked")).toBeTruthy();
@@ -142,11 +179,7 @@ describe("/livestock/enter-herd-details tests", () => {
       expect(await axe(res.payload)).toHaveNoViolations();
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
-      expect($("title").text().trim()).toContain(
-        "Livestock flock details - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
-      );
       expect($(".govuk-back-link").attr("href")).toContain("/livestock/sbi-herds");
-      expect($(".govuk-heading-l").text().trim()).toBe("Enter the flock details");
       expect($(".govuk-hint").text().trim()).toContain("Tell us about this flock");
       const legendText = $(".govuk-fieldset__legend--m").text().trim();
       expect(legendText).toBe(
@@ -171,11 +204,7 @@ describe("/livestock/enter-herd-details tests", () => {
       expect(await axe(res.payload)).toHaveNoViolations();
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
-      expect($("title").text().trim()).toContain(
-        "Livestock herd details - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
-      );
       expect($(".govuk-back-link").attr("href")).toContain("/livestock/cph");
-      expect($(".govuk-heading-l").text().trim()).toBe("Enter the herd details");
       expect($(".govuk-hint").text().trim()).toContain("Tell us about this herd");
       const legendText = $(".govuk-fieldset__legend--m").text().trim();
       expect(legendText).toBe(
@@ -200,11 +229,7 @@ describe("/livestock/enter-herd-details tests", () => {
       expect(await axe(res.payload)).toHaveNoViolations();
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
-      expect($("title").text().trim()).toContain(
-        "Livestock herd details - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
-      );
       expect($(".govuk-back-link").attr("href")).toContain("/livestock/sbi-herds");
-      expect($(".govuk-heading-l").text().trim()).toBe("Enter the herd details");
       expect($(".govuk-hint").text().trim()).toContain("Tell us about this herd");
       const legendText = $(".govuk-fieldset__legend--m").text().trim();
       expect(legendText).toBe(

--- a/test/integration/narrow/routes/livestock/claim/enter-herd-name.test.js
+++ b/test/integration/narrow/routes/livestock/claim/enter-herd-name.test.js
@@ -11,6 +11,7 @@ import {
 } from "../../../../../../app/session/index.js";
 import { when } from "jest-when";
 import { axe } from "../../../../../helpers/axe-helper.js";
+import { testBrowserPageTitle } from "../../../../../helpers/page-title-and-heading.js";
 
 jest.mock("../../../../../../app/session/index.js");
 
@@ -64,9 +65,6 @@ describe("/livestock/herd-name tests", () => {
   });
 
   const expectHerdText = ($) => {
-    expect($("title").text().trim()).toContain(
-      "Livestock herd name - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
-    );
     expect($(".govuk-label--l").text().trim()).toBe("Enter the herd name");
     expect($(".govuk-hint").text().trim()).toContain("Tell us about this herd");
     expect($(".govuk-details__summary-text").text().trim()).toBe(
@@ -77,9 +75,6 @@ describe("/livestock/herd-name tests", () => {
   };
 
   const expectFlockText = ($) => {
-    expect($("title").text().trim()).toContain(
-      "Livestock flock name - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
-    );
     expect($(".govuk-label--l").text().trim()).toBe("Enter the flock name");
     expect($(".govuk-hint").text().trim()).toContain("Tell us about this flock");
     expect($(".govuk-details__summary-text").text().trim()).toBe(
@@ -89,6 +84,32 @@ describe("/livestock/herd-name tests", () => {
   };
 
   describe("GET", () => {
+    const getResponse = (session) => () => {
+      when(getSessionData)
+        .calledWith(expect.anything(), sessionEntryKeys.endemicsClaim)
+        .mockReturnValue(session);
+      return server.inject({ method: "GET", url, auth });
+    };
+
+    testBrowserPageTitle({
+      title: "Livestock herd name",
+      getResponse: getResponse({
+        reference: "TEMP-6GSE-PIR8",
+        typeOfReview: "REVIEW",
+        typeOfLivestock: "beef",
+        herds: [{ id: "1" }],
+      }),
+    });
+    testBrowserPageTitle({
+      title: "Livestock flock name",
+      getResponse: getResponse({
+        reference: "TEMP-6GSE-PIR8",
+        typeOfReview: "REVIEW",
+        typeOfLivestock: "sheep",
+        herds: [{ id: "1" }],
+      }),
+    });
+
     test("returns 200 with herd labels when species beef", async () => {
       when(getSessionData)
         .calledWith(expect.anything(), sessionEntryKeys.endemicsClaim)

--- a/test/integration/narrow/routes/livestock/claim/number-of-blood-samples.test.js
+++ b/test/integration/narrow/routes/livestock/claim/number-of-blood-samples.test.js
@@ -15,6 +15,7 @@ import {
   testBrowserPageTitle,
   testPageHeading,
 } from "../../../../../helpers/page-title-and-heading.js";
+import { testRedirectsToSignInWhenLoggedOut } from "../../../../../helpers/sign-in-redirect.js";
 
 jest.mock("../../../../../../app/messaging/ineligibility-event-emission.js");
 jest.mock("../../../../../../app/session/index.js");
@@ -81,16 +82,8 @@ describe("Number of blood samples test", () => {
       expectPhaseBanner.ok($);
     });
 
-    test("when not logged in redirects to /sign-in", async () => {
-      const options = {
-        method: "GET",
-        url,
-      };
-
-      const res = await server.inject(options);
-
-      expect(res.statusCode).toBe(302);
-      expect(res.headers.location.toString()).toEqual("/sign-in");
+    testRedirectsToSignInWhenLoggedOut({
+      getResponse: () => server.inject({ method: "GET", url }),
     });
   });
 
@@ -101,18 +94,14 @@ describe("Number of blood samples test", () => {
       crumb = await getCrumbs(server);
     });
 
-    test("when not logged in redirects to /sign-in", async () => {
-      const options = {
-        method: "POST",
-        url,
-        payload: { crumb, numberOfBloodSamples: 30 },
-        headers: { cookie: `crumb=${crumb}` },
-      };
-
-      const res = await server.inject(options);
-
-      expect(res.statusCode).toBe(302);
-      expect(res.headers.location.toString()).toEqual("/sign-in");
+    testRedirectsToSignInWhenLoggedOut({
+      getResponse: () =>
+        server.inject({
+          method: "POST",
+          url,
+          payload: { crumb, numberOfBloodSamples: 30 },
+          headers: { cookie: `crumb=${crumb}` },
+        }),
     });
 
     test("shows error when payload is invalid", async () => {

--- a/test/integration/narrow/routes/livestock/claim/number-of-blood-samples.test.js
+++ b/test/integration/narrow/routes/livestock/claim/number-of-blood-samples.test.js
@@ -11,6 +11,10 @@ import expectPhaseBanner from "assert";
 import { getCrumbs } from "../../../../../utils/get-crumbs.js";
 import { thresholds } from "../../../../../../app/constants/claim-constants.js";
 import { when } from "jest-when";
+import {
+  testBrowserPageTitle,
+  testPageHeading,
+} from "../../../../../helpers/page-title-and-heading.js";
 
 jest.mock("../../../../../../app/messaging/ineligibility-event-emission.js");
 jest.mock("../../../../../../app/session/index.js");
@@ -64,21 +68,16 @@ describe("Number of blood samples test", () => {
   });
 
   describe(`GET ${url} route`, () => {
-    test("returns 200", async () => {
-      const options = {
-        method: "GET",
-        url,
-        auth,
-      };
+    const getResponse = () => server.inject({ method: "GET", url, auth });
 
-      const res = await server.inject(options);
+    testBrowserPageTitle({ title: "Number of livestock blood samples", getResponse });
+    testPageHeading({ heading: "How many blood samples were tested?", getResponse });
+
+    test("returns 200", async () => {
+      const res = await getResponse();
 
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
-      expect($("h1").text()).toMatch("How many blood samples were tested?");
-      expect($("title").text()).toContain(
-        "Number of livestock blood samples - Get funding to improve animal health and welfare",
-      );
       expectPhaseBanner.ok($);
     });
 

--- a/test/integration/narrow/routes/livestock/claim/number-of-fluid-oral-samples.test.js
+++ b/test/integration/narrow/routes/livestock/claim/number-of-fluid-oral-samples.test.js
@@ -10,6 +10,10 @@ import expectPhaseBanner from "assert";
 import { getCrumbs } from "../../../../../utils/get-crumbs.js";
 import { sendInvalidDataEvent } from "../../../../../../app/messaging/ineligibility-event-emission.js";
 import { when } from "jest-when";
+import {
+  testBrowserPageTitle,
+  testPageHeading,
+} from "../../../../../helpers/page-title-and-heading.js";
 
 jest.mock("../../../../../../app/messaging/ineligibility-event-emission.js");
 jest.mock("../../../../../../app/session/index.js");
@@ -64,16 +68,17 @@ describe("Number of fluid oral samples test", () => {
   });
 
   describe(`GET ${url} route`, () => {
+    const getResponse = () => server.inject({ method: "GET", url, auth });
+
+    testBrowserPageTitle({ title: "Number of livestock oral fluid samples", getResponse });
+    testPageHeading({ heading: "How many oral fluid samples were tested?", getResponse });
+
     test("should return 200 and have back link to endemicsTestUrn when visit before Pigs&Payments golive", async () => {
       const options = { method: "GET", url, auth };
       const res = await server.inject(options);
 
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
-      expect($("h1").text()).toMatch("How many oral fluid samples were tested?");
-      expect($("title").text()).toContain(
-        "Number of livestock oral fluid samples - Get funding to improve animal health and welfare",
-      );
       expect($("#back").attr("href")).toBe("/livestock/test-urn");
       expectPhaseBanner.ok($);
     });
@@ -92,10 +97,6 @@ describe("Number of fluid oral samples test", () => {
 
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
-      expect($("h1").text()).toMatch("How many oral fluid samples were tested?");
-      expect($("title").text()).toContain(
-        "Number of livestock oral fluid samples - Get funding to improve animal health and welfare",
-      );
       expect($("#back").attr("href")).toBe("/livestock/samples-types");
       expectPhaseBanner.ok($);
     });

--- a/test/integration/narrow/routes/livestock/claim/number-of-fluid-oral-samples.test.js
+++ b/test/integration/narrow/routes/livestock/claim/number-of-fluid-oral-samples.test.js
@@ -14,6 +14,7 @@ import {
   testBrowserPageTitle,
   testPageHeading,
 } from "../../../../../helpers/page-title-and-heading.js";
+import { testRedirectsToSignInWhenLoggedOut } from "../../../../../helpers/sign-in-redirect.js";
 
 jest.mock("../../../../../../app/messaging/ineligibility-event-emission.js");
 jest.mock("../../../../../../app/session/index.js");
@@ -101,16 +102,8 @@ describe("Number of fluid oral samples test", () => {
       expectPhaseBanner.ok($);
     });
 
-    test("when not logged in redirects to /sign-in", async () => {
-      const options = {
-        method: "GET",
-        url,
-      };
-
-      const res = await server.inject(options);
-
-      expect(res.statusCode).toBe(302);
-      expect(res.headers.location.toString()).toEqual(`/sign-in`);
+    testRedirectsToSignInWhenLoggedOut({
+      getResponse: () => server.inject({ method: "GET", url }),
     });
   });
 
@@ -121,18 +114,14 @@ describe("Number of fluid oral samples test", () => {
       crumb = await getCrumbs(server);
     });
 
-    test("when not logged in redirects to /sign-in", async () => {
-      const options = {
-        method: "POST",
-        url,
-        payload: { crumb, numberOfOralFluidSamples: "123" },
-        headers: { cookie: `crumb=${crumb}` },
-      };
-
-      const res = await server.inject(options);
-
-      expect(res.statusCode).toBe(302);
-      expect(res.headers.location.toString()).toEqual(`/sign-in`);
+    testRedirectsToSignInWhenLoggedOut({
+      getResponse: () =>
+        server.inject({
+          method: "POST",
+          url,
+          payload: { crumb, numberOfOralFluidSamples: "123" },
+          headers: { cookie: `crumb=${crumb}` },
+        }),
     });
 
     test("shows error when payload is invalid", async () => {

--- a/test/integration/narrow/routes/livestock/claim/number-of-samples-tested.test.js
+++ b/test/integration/narrow/routes/livestock/claim/number-of-samples-tested.test.js
@@ -14,6 +14,7 @@ import {
   testBrowserPageTitle,
   testPageHeading,
 } from "../../../../../helpers/page-title-and-heading.js";
+import { testRedirectsToSignInWhenLoggedOut } from "../../../../../helpers/sign-in-redirect.js";
 
 jest.mock("../../../../../../app/messaging/ineligibility-event-emission.js");
 jest.mock("../../../../../../app/session/index.js");
@@ -80,16 +81,8 @@ describe("Number of samples tested test", () => {
       expectPhaseBanner.ok($);
     });
 
-    test("when not logged in redirects to /sign-in", async () => {
-      const options = {
-        method: "GET",
-        url,
-      };
-
-      const res = await server.inject(options);
-
-      expect(res.statusCode).toBe(302);
-      expect(res.headers.location.toString()).toEqual(`/sign-in`);
+    testRedirectsToSignInWhenLoggedOut({
+      getResponse: () => server.inject({ method: "GET", url }),
     });
   });
 
@@ -100,18 +93,14 @@ describe("Number of samples tested test", () => {
       crumb = await getCrumbs(server);
     });
 
-    test("when not logged in redirects to /sign-in", async () => {
-      const options = {
-        method: "POST",
-        url,
-        payload: { crumb, numberOfSamplesTested: "123" },
-        headers: { cookie: `crumb=${crumb}` },
-      };
-
-      const res = await server.inject(options);
-
-      expect(res.statusCode).toBe(302);
-      expect(res.headers.location.toString()).toEqual(`/sign-in`);
+    testRedirectsToSignInWhenLoggedOut({
+      getResponse: () =>
+        server.inject({
+          method: "POST",
+          url,
+          payload: { crumb, numberOfSamplesTested: "123" },
+          headers: { cookie: `crumb=${crumb}` },
+        }),
     });
 
     test("shows error when payload is empty", async () => {

--- a/test/integration/narrow/routes/livestock/claim/number-of-samples-tested.test.js
+++ b/test/integration/narrow/routes/livestock/claim/number-of-samples-tested.test.js
@@ -10,6 +10,10 @@ import expectPhaseBanner from "assert";
 import { getCrumbs } from "../../../../../utils/get-crumbs.js";
 import { sendInvalidDataEvent } from "../../../../../../app/messaging/ineligibility-event-emission.js";
 import { when } from "jest-when";
+import {
+  testBrowserPageTitle,
+  testPageHeading,
+} from "../../../../../helpers/page-title-and-heading.js";
 
 jest.mock("../../../../../../app/messaging/ineligibility-event-emission.js");
 jest.mock("../../../../../../app/session/index.js");
@@ -59,21 +63,16 @@ describe("Number of samples tested test", () => {
   });
 
   describe(`GET ${url} route`, () => {
-    test("returns 200 and expected content", async () => {
-      const options = {
-        method: "GET",
-        url,
-        auth,
-      };
+    const getResponse = () => server.inject({ method: "GET", url, auth });
 
-      const res = await server.inject(options);
+    testBrowserPageTitle({ title: "Number of livestock samples tested", getResponse });
+    testPageHeading({ heading: "How many samples were tested?", getResponse });
+
+    test("returns 200 and expected content", async () => {
+      const res = await getResponse();
 
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
-      expect($("h1").text()).toMatch("How many samples were tested?");
-      expect($("title").text()).toContain(
-        "Number of livestock samples tested - Get funding to improve animal health and welfare",
-      );
       expect($(".govuk-hint").text().trim()).toEqual(
         "Enter how many polymerase chain reaction (PCR) and enzyme-linked immunosorbent assay (ELISA) test results you got back. You can find this on the summary the vet gave you.",
       );

--- a/test/integration/narrow/routes/livestock/claim/number-of-species-tested.test.js
+++ b/test/integration/narrow/routes/livestock/claim/number-of-species-tested.test.js
@@ -6,10 +6,13 @@ import {
   sessionKeys,
   setSessionData,
 } from "../../../../../../app/session/index.js";
-import expectPhaseBanner from "assert";
 import { getCrumbs } from "../../../../../utils/get-crumbs.js";
 import { isVisitDateAfterPIHuntAndDairyGoLive } from "../../../../../../app/lib/context-helper.js";
 import { when } from "jest-when";
+import {
+  testBrowserPageTitle,
+  testPageHeading,
+} from "../../../../../helpers/page-title-and-heading.js";
 import { sendInvalidDataEvent } from "../../../../../../app/messaging/ineligibility-event-emission.js";
 
 jest.mock("../../../../../../app/messaging/ineligibility-event-emission.js");
@@ -59,59 +62,25 @@ describe("Number of species tested test", () => {
   });
 
   describe(`GET ${url} route`, () => {
-    test("returns 200", async () => {
+    const getResponse = (session) => () => {
       when(getSessionData)
         .calledWith(expect.anything(), sessionEntryKeys.endemicsClaim)
-        .mockReturnValue({
-          typeOfLivestock: "pigs",
-          reference: "TEMP-6GSE-PIR8",
-        });
+        .mockReturnValue(session);
+      return server.inject({ method: "GET", url, auth });
+    };
 
-      const options = {
-        method: "GET",
-        url,
-        auth,
-      };
-
-      const res = await server.inject(options);
-
-      expect(res.statusCode).toBe(200);
-      const $ = cheerio.load(res.payload);
-      expect($("h1").text()).toMatch("How many animals were samples taken from?");
-      expect($("title").text().trim()).toContain(
-        "Number of animals livestock samples were taken from - Get funding to improve animal health and welfare",
-      );
-      expectPhaseBanner.ok($);
+    testBrowserPageTitle({
+      title: "Number of animals livestock samples were taken from",
+      getResponse: getResponse({ typeOfLivestock: "pigs", reference: "TEMP-6GSE-PIR8" }),
     });
-
-    test.each([
-      { typeOfLivestock: "beef", typeOfReview: "REVIEW" },
-      { typeOfLivestock: "dairy", typeOfReview: "REVIEW" },
-    ])(
-      "returns 200 for review $typeOfLivestock journey",
-      async ({ typeOfLivestock, typeOfReview }) => {
-        when(getSessionData)
-          .calledWith(expect.anything(), sessionEntryKeys.endemicsClaim)
-          .mockReturnValue({ typeOfLivestock, typeOfReview });
-
-        const options = {
-          method: "GET",
-          url,
-          auth,
-        };
-
-        const res = await server.inject(options);
-
-        expect(res.statusCode).toBe(200);
-        const $ = cheerio.load(res.payload);
-        expect($("h1").text()).toMatch(
-          typeOfLivestock === "dairy"
-            ? "How many animals were samples taken from or assessed?"
-            : "How many animals were samples taken from?",
-        );
-        expectPhaseBanner.ok($);
-      },
-    );
+    testPageHeading({
+      heading: "How many animals were samples taken from?",
+      getResponse: getResponse({ typeOfLivestock: "beef", typeOfReview: "REVIEW" }),
+    });
+    testPageHeading({
+      heading: "How many animals were samples taken from or assessed?",
+      getResponse: getResponse({ typeOfLivestock: "dairy", typeOfReview: "REVIEW" }),
+    });
 
     test("when not logged in redirects to /sign-in", async () => {
       const options = {

--- a/test/integration/narrow/routes/livestock/claim/number-of-species-tested.test.js
+++ b/test/integration/narrow/routes/livestock/claim/number-of-species-tested.test.js
@@ -13,6 +13,7 @@ import {
   testBrowserPageTitle,
   testPageHeading,
 } from "../../../../../helpers/page-title-and-heading.js";
+import { testRedirectsToSignInWhenLoggedOut } from "../../../../../helpers/sign-in-redirect.js";
 import { sendInvalidDataEvent } from "../../../../../../app/messaging/ineligibility-event-emission.js";
 
 jest.mock("../../../../../../app/messaging/ineligibility-event-emission.js");
@@ -82,16 +83,8 @@ describe("Number of species tested test", () => {
       getResponse: getResponse({ typeOfLivestock: "dairy", typeOfReview: "REVIEW" }),
     });
 
-    test("when not logged in redirects to /sign-in", async () => {
-      const options = {
-        method: "GET",
-        url,
-      };
-
-      const res = await server.inject(options);
-
-      expect(res.statusCode).toBe(302);
-      expect(res.headers.location.toString()).toEqual(`/sign-in`);
+    testRedirectsToSignInWhenLoggedOut({
+      getResponse: () => server.inject({ method: "GET", url }),
     });
   });
 
@@ -104,18 +97,14 @@ describe("Number of species tested test", () => {
       jest.clearAllMocks();
     });
 
-    test("when not logged in redirects to /sign-in", async () => {
-      const options = {
-        method: "POST",
-        url,
-        payload: { crumb, numberAnimalsTested: "123" },
-        headers: { cookie: `crumb=${crumb}` },
-      };
-
-      const res = await server.inject(options);
-
-      expect(res.statusCode).toBe(302);
-      expect(res.headers.location.toString()).toEqual(`/sign-in`);
+    testRedirectsToSignInWhenLoggedOut({
+      getResponse: () =>
+        server.inject({
+          method: "POST",
+          url,
+          payload: { crumb, numberAnimalsTested: "123" },
+          headers: { cookie: `crumb=${crumb}` },
+        }),
     });
 
     test.each([

--- a/test/integration/narrow/routes/livestock/claim/pi-hunt-all-animals.test.js
+++ b/test/integration/narrow/routes/livestock/claim/pi-hunt-all-animals.test.js
@@ -14,6 +14,7 @@ import {
   testBrowserPageTitle,
   testPageHeading,
 } from "../../../../../helpers/page-title-and-heading.js";
+import { testRedirectsToSignInWhenLoggedOut } from "../../../../../helpers/sign-in-redirect.js";
 import { sendInvalidDataEvent } from "../../../../../../app/messaging/ineligibility-event-emission.js";
 
 jest.mock("../../../../../../app/session/index.js");
@@ -116,16 +117,8 @@ describe("PI Hunt recommended tests", () => {
       expectPhaseBanner.ok($);
     });
 
-    test("when not logged in redirects to /sign-in", async () => {
-      const options = {
-        method: "GET",
-        url,
-      };
-
-      const res = await server.inject(options);
-
-      expect(res.statusCode).toBe(302);
-      expect(res.headers.location.toString()).toEqual(`/sign-in`);
+    testRedirectsToSignInWhenLoggedOut({
+      getResponse: () => server.inject({ method: "GET", url }),
     });
   });
 
@@ -136,18 +129,14 @@ describe("PI Hunt recommended tests", () => {
       crumb = await getCrumbs(server);
     });
 
-    test("when not logged in redirects to /sign-in", async () => {
-      const options = {
-        method: "POST",
-        url,
-        payload: { crumb },
-        headers: { cookie: `crumb=${crumb}` },
-      };
-
-      const res = await server.inject(options);
-
-      expect(res.statusCode).toBe(302);
-      expect(res.headers.location.toString()).toEqual(`/sign-in`);
+    testRedirectsToSignInWhenLoggedOut({
+      getResponse: () =>
+        server.inject({
+          method: "POST",
+          url,
+          payload: { crumb },
+          headers: { cookie: `crumb=${crumb}` },
+        }),
     });
 
     test("Continue to eligible page if user select yes", async () => {

--- a/test/integration/narrow/routes/livestock/claim/pi-hunt-all-animals.test.js
+++ b/test/integration/narrow/routes/livestock/claim/pi-hunt-all-animals.test.js
@@ -100,7 +100,7 @@ describe("PI Hunt recommended tests", () => {
     ])("returns 200", async ({ typeOfLivestock, reviewTestResults, backLink }) => {
       when(getSessionData)
         .calledWith(expect.anything(), sessionEntryKeys.endemicsClaim)
-        .mockReturnValueOnce({ typeOfLivestock, reviewTestResults });
+        .mockReturnValue({ typeOfLivestock, reviewTestResults });
 
       const options = {
         method: "GET",

--- a/test/integration/narrow/routes/livestock/claim/pi-hunt-all-animals.test.js
+++ b/test/integration/narrow/routes/livestock/claim/pi-hunt-all-animals.test.js
@@ -10,6 +10,10 @@ import expectPhaseBanner from "assert";
 import { getCrumbs } from "../../../../../utils/get-crumbs.js";
 import { getAmount } from "ffc-ahwr-common-library";
 import { when } from "jest-when";
+import {
+  testBrowserPageTitle,
+  testPageHeading,
+} from "../../../../../helpers/page-title-and-heading.js";
 import { sendInvalidDataEvent } from "../../../../../../app/messaging/ineligibility-event-emission.js";
 
 jest.mock("../../../../../../app/session/index.js");
@@ -61,45 +65,56 @@ describe("PI Hunt recommended tests", () => {
   });
 
   describe(`GET ${url} route`, () => {
+    const getResponse = (session) => () => {
+      when(getSessionData)
+        .calledWith(expect.anything(), sessionEntryKeys.endemicsClaim)
+        .mockReturnValue(session);
+      return server.inject({ method: "GET", auth, url });
+    };
+
+    testBrowserPageTitle({
+      title: "Persistently infected hunt done on all livestock in herd",
+      getResponse: getResponse({ typeOfLivestock: "beef", reviewTestResults: "positive" }),
+    });
+    testPageHeading({
+      heading: "Was the PI hunt done on all beef cattle in the herd?",
+      getResponse: getResponse({ typeOfLivestock: "beef", reviewTestResults: "positive" }),
+    });
+    testPageHeading({
+      heading: "Was the PI hunt done on all dairy cattle in the herd?",
+      getResponse: getResponse({ typeOfLivestock: "dairy", reviewTestResults: "negative" }),
+    });
+
     test.each([
       {
         typeOfLivestock: "beef",
         reviewTestResults: "positive",
         backLink: "/livestock/pi-hunt",
-        expectedQuestion: "Was the PI hunt done on all beef cattle in the herd?",
       },
       {
         typeOfLivestock: "dairy",
         reviewTestResults: "negative",
         backLink: "/livestock/pi-hunt-recommended",
-        expectedQuestion: "Was the PI hunt done on all dairy cattle in the herd?",
       },
-    ])(
-      "returns 200",
-      async ({ typeOfLivestock, reviewTestResults, backLink, expectedQuestion }) => {
-        when(getSessionData)
-          .calledWith(expect.anything(), sessionEntryKeys.endemicsClaim)
-          .mockReturnValueOnce({ typeOfLivestock, reviewTestResults });
+    ])("returns 200", async ({ typeOfLivestock, reviewTestResults, backLink }) => {
+      when(getSessionData)
+        .calledWith(expect.anything(), sessionEntryKeys.endemicsClaim)
+        .mockReturnValueOnce({ typeOfLivestock, reviewTestResults });
 
-        const options = {
-          method: "GET",
-          auth,
-          url,
-        };
+      const options = {
+        method: "GET",
+        auth,
+        url,
+      };
 
-        const res = await server.inject(options);
-        const $ = cheerio.load(res.payload);
+      const res = await server.inject(options);
+      const $ = cheerio.load(res.payload);
 
-        expect(res.statusCode).toBe(200);
-        expect($(".govuk-fieldset__heading").text().trim()).toEqual(expectedQuestion);
-        expect($("title").text()).toContain(
-          "Persistently infected hunt done on all livestock in herd - Get funding to improve animal health and welfare",
-        );
-        expect($(".govuk-radios__item").length).toEqual(2);
-        expect($(".govuk-back-link").attr("href")).toContain(backLink);
-        expectPhaseBanner.ok($);
-      },
-    );
+      expect(res.statusCode).toBe(200);
+      expect($(".govuk-radios__item").length).toEqual(2);
+      expect($(".govuk-back-link").attr("href")).toContain(backLink);
+      expectPhaseBanner.ok($);
+    });
 
     test("when not logged in redirects to /sign-in", async () => {
       const options = {

--- a/test/integration/narrow/routes/livestock/claim/pi-hunt-recommended.test.js
+++ b/test/integration/narrow/routes/livestock/claim/pi-hunt-recommended.test.js
@@ -15,6 +15,7 @@ import {
   testBrowserPageTitle,
   testPageHeading,
 } from "../../../../../helpers/page-title-and-heading.js";
+import { testRedirectsToSignInWhenLoggedOut } from "../../../../../helpers/sign-in-redirect.js";
 
 jest.mock("../../../../../../app/session/index.js");
 jest.mock("ffc-ahwr-common-library");
@@ -78,16 +79,8 @@ describe("PI Hunt recommended tests", () => {
       expectPhaseBanner.ok($);
     });
 
-    test("when not logged in redirects to /sign-in", async () => {
-      const options = {
-        method: "GET",
-        url,
-      };
-
-      const res = await server.inject(options);
-
-      expect(res.statusCode).toBe(302);
-      expect(res.headers.location.toString()).toEqual(`/sign-in`);
+    testRedirectsToSignInWhenLoggedOut({
+      getResponse: () => server.inject({ method: "GET", url }),
     });
   });
 
@@ -98,18 +91,14 @@ describe("PI Hunt recommended tests", () => {
       crumb = await getCrumbs(server);
     });
 
-    test("when not logged in redirects to /sign-in", async () => {
-      const options = {
-        method: "POST",
-        url,
-        payload: { crumb },
-        headers: { cookie: `crumb=${crumb}` },
-      };
-
-      const res = await server.inject(options);
-
-      expect(res.statusCode).toBe(302);
-      expect(res.headers.location.toString()).toEqual(`/sign-in`);
+    testRedirectsToSignInWhenLoggedOut({
+      getResponse: () =>
+        server.inject({
+          method: "POST",
+          url,
+          payload: { crumb },
+          headers: { cookie: `crumb=${crumb}` },
+        }),
     });
 
     test("Continue to eligible page if user select yes", async () => {

--- a/test/integration/narrow/routes/livestock/claim/pi-hunt-recommended.test.js
+++ b/test/integration/narrow/routes/livestock/claim/pi-hunt-recommended.test.js
@@ -11,6 +11,10 @@ import { getCrumbs } from "../../../../../utils/get-crumbs.js";
 import { getAmount } from "ffc-ahwr-common-library";
 import { sendInvalidDataEvent } from "../../../../../../app/messaging/ineligibility-event-emission.js";
 import { when } from "jest-when";
+import {
+  testBrowserPageTitle,
+  testPageHeading,
+} from "../../../../../helpers/page-title-and-heading.js";
 
 jest.mock("../../../../../../app/session/index.js");
 jest.mock("ffc-ahwr-common-library");
@@ -60,23 +64,16 @@ describe("PI Hunt recommended tests", () => {
   });
 
   describe(`GET ${url} route`, () => {
-    test("returns 200", async () => {
-      const options = {
-        method: "GET",
-        auth,
-        url,
-      };
+    const getResponse = () => server.inject({ method: "GET", auth, url });
 
-      const res = await server.inject(options);
+    testBrowserPageTitle({ title: "PI hunt recommended for livestock", getResponse });
+    testPageHeading({ heading: "Was the PI hunt recommended by the vet?", getResponse });
+
+    test("returns 200", async () => {
+      const res = await getResponse();
       const $ = cheerio.load(res.payload);
 
       expect(res.statusCode).toBe(200);
-      expect($(".govuk-fieldset__heading").text().trim()).toEqual(
-        "Was the PI hunt recommended by the vet?",
-      );
-      expect($("title").text()).toContain(
-        "PI hunt recommended for livestock - Get funding to improve animal health and welfare",
-      );
       expect($(".govuk-radios__item").length).toEqual(2);
       expectPhaseBanner.ok($);
     });

--- a/test/integration/narrow/routes/livestock/claim/pi-hunt.test.js
+++ b/test/integration/narrow/routes/livestock/claim/pi-hunt.test.js
@@ -12,6 +12,10 @@ import { isVisitDateAfterPIHuntAndDairyGoLive } from "../../../../../../app/lib/
 import { clearPiHuntSessionOnChange } from "../../../../../../app/lib/clear-pi-hunt-session-on-change.js";
 import { sendInvalidDataEvent } from "../../../../../../app/messaging/ineligibility-event-emission.js";
 import { when } from "jest-when";
+import {
+  testBrowserPageTitle,
+  testPageHeading,
+} from "../../../../../helpers/page-title-and-heading.js";
 
 jest.mock("../../../../../../app/session/index.js");
 jest.mock("../../../../../../app/messaging/ineligibility-event-emission.js");
@@ -68,23 +72,23 @@ describe("PI Hunt tests when Optional PI Hunt is OFF", () => {
   });
 
   describe(`GET ${url} route`, () => {
-    test("returns 200", async () => {
-      const options = {
-        method: "GET",
-        auth,
-        url,
-      };
+    const getResponse = () => server.inject({ method: "GET", auth, url });
 
-      const res = await server.inject(options);
+    testBrowserPageTitle({
+      title: "Persistently infected hunt for bovine viral diarrhoea done on livestock",
+      getResponse,
+    });
+    testPageHeading({
+      heading:
+        "Was a persistently infected (PI) hunt for bovine viral diarrhoea (BVD) done on all animals in the herd?",
+      getResponse,
+    });
+
+    test("returns 200", async () => {
+      const res = await getResponse();
       const $ = cheerio.load(res.payload);
 
       expect(res.statusCode).toBe(200);
-      expect($(".govuk-fieldset__heading").text().trim()).toEqual(
-        "Was a persistently infected (PI) hunt for bovine viral diarrhoea (BVD) done on all animals in the herd?",
-      );
-      expect($("title").text().trim()).toContain(
-        "Persistently infected hunt for bovine viral diarrhoea done on livestock - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
-      );
       expect($(".govuk-radios__item").length).toEqual(2);
       expectPhaseBanner.ok($);
     });

--- a/test/integration/narrow/routes/livestock/claim/pi-hunt.test.js
+++ b/test/integration/narrow/routes/livestock/claim/pi-hunt.test.js
@@ -16,6 +16,7 @@ import {
   testBrowserPageTitle,
   testPageHeading,
 } from "../../../../../helpers/page-title-and-heading.js";
+import { testRedirectsToSignInWhenLoggedOut } from "../../../../../helpers/sign-in-redirect.js";
 
 jest.mock("../../../../../../app/session/index.js");
 jest.mock("../../../../../../app/messaging/ineligibility-event-emission.js");
@@ -93,16 +94,8 @@ describe("PI Hunt tests when Optional PI Hunt is OFF", () => {
       expectPhaseBanner.ok($);
     });
 
-    test("when not logged in redirects to /sign-in", async () => {
-      const options = {
-        method: "GET",
-        url,
-      };
-
-      const res = await server.inject(options);
-
-      expect(res.statusCode).toBe(302);
-      expect(res.headers.location.toString()).toEqual(`/sign-in`);
+    testRedirectsToSignInWhenLoggedOut({
+      getResponse: () => server.inject({ method: "GET", url }),
     });
   });
 
@@ -114,18 +107,14 @@ describe("PI Hunt tests when Optional PI Hunt is OFF", () => {
       jest.resetAllMocks();
     });
 
-    test("when not logged in redirects to /sign-in", async () => {
-      const options = {
-        method: "POST",
-        url,
-        payload: { crumb, laboratoryURN: "123" },
-        headers: { cookie: `crumb=${crumb}` },
-      };
-
-      const res = await server.inject(options);
-
-      expect(res.statusCode).toBe(302);
-      expect(res.headers.location.toString()).toEqual(`/sign-in`);
+    testRedirectsToSignInWhenLoggedOut({
+      getResponse: () =>
+        server.inject({
+          method: "POST",
+          url,
+          payload: { crumb, laboratoryURN: "123" },
+          headers: { cookie: `crumb=${crumb}` },
+        }),
     });
     test("Continue to eligible page if user select yes", async () => {
       const options = {

--- a/test/integration/narrow/routes/livestock/claim/pigs-elisa-result.test.js
+++ b/test/integration/narrow/routes/livestock/claim/pigs-elisa-result.test.js
@@ -9,6 +9,10 @@ import {
 import expectPhaseBanner from "assert";
 import { getCrumbs } from "../../../../../utils/get-crumbs.js";
 import { when } from "jest-when";
+import {
+  testBrowserPageTitle,
+  testPageHeading,
+} from "../../../../../helpers/page-title-and-heading.js";
 
 jest.mock("../../../../../../app/session/index.js");
 
@@ -61,22 +65,16 @@ describe("pigs elisa result test", () => {
   });
 
   describe(`GET ${url} route`, () => {
-    test("returns 200", async () => {
-      const options = {
-        method: "GET",
-        url,
-        auth,
-      };
+    const getResponse = () => server.inject({ method: "GET", url, auth });
 
-      const res = await server.inject(options);
+    testBrowserPageTitle({ title: "Pig livestock ELISA result", getResponse });
+    testPageHeading({ heading: "What was the result of the ELISA test?", getResponse });
+
+    test("returns 200", async () => {
+      const res = await getResponse();
 
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
-      expect($("h1").text()).toMatch("What was the result of the ELISA test?");
-      expect($("title").text()).toContain(
-        "Pig livestock ELISA result - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
-      );
-
       expectPhaseBanner.ok($);
     });
 

--- a/test/integration/narrow/routes/livestock/claim/pigs-elisa-result.test.js
+++ b/test/integration/narrow/routes/livestock/claim/pigs-elisa-result.test.js
@@ -13,6 +13,7 @@ import {
   testBrowserPageTitle,
   testPageHeading,
 } from "../../../../../helpers/page-title-and-heading.js";
+import { testRedirectsToSignInWhenLoggedOut } from "../../../../../helpers/sign-in-redirect.js";
 
 jest.mock("../../../../../../app/session/index.js");
 
@@ -78,16 +79,8 @@ describe("pigs elisa result test", () => {
       expectPhaseBanner.ok($);
     });
 
-    test("when not logged in redirects to /sign-in", async () => {
-      const options = {
-        method: "GET",
-        url,
-      };
-
-      const res = await server.inject(options);
-
-      expect(res.statusCode).toBe(302);
-      expect(res.headers.location.toString()).toEqual(`/sign-in`);
+    testRedirectsToSignInWhenLoggedOut({
+      getResponse: () => server.inject({ method: "GET", url }),
     });
   });
 
@@ -107,18 +100,14 @@ describe("pigs elisa result test", () => {
       headers: { cookie: `crumb=${crumb}` },
     });
 
-    test("when not logged in redirects to /sign-in", async () => {
-      const options = {
-        method: "POST",
-        url,
-        payload: { crumb, elisaResult: "positive" },
-        headers: { cookie: `crumb=${crumb}` },
-      };
-
-      const res = await server.inject(options);
-
-      expect(res.statusCode).toBe(302);
-      expect(res.headers.location.toString()).toEqual(`/sign-in`);
+    testRedirectsToSignInWhenLoggedOut({
+      getResponse: () =>
+        server.inject({
+          method: "POST",
+          url,
+          payload: { crumb, elisaResult: "positive" },
+          headers: { cookie: `crumb=${crumb}` },
+        }),
     });
 
     test("shows error when payload is invalid", async () => {

--- a/test/integration/narrow/routes/livestock/claim/pigs-genetic-sequencing.test.js
+++ b/test/integration/narrow/routes/livestock/claim/pigs-genetic-sequencing.test.js
@@ -9,6 +9,10 @@ import {
 import expectPhaseBanner from "assert";
 import { getCrumbs } from "../../../../../utils/get-crumbs.js";
 import { when } from "jest-when";
+import {
+  testBrowserPageTitle,
+  testPageHeading,
+} from "../../../../../helpers/page-title-and-heading.js";
 
 jest.mock("../../../../../../app/session/index.js");
 
@@ -58,22 +62,16 @@ describe("pigs genetic sequencing test", () => {
   });
 
   describe(`GET ${url} route`, () => {
-    test("returns 200", async () => {
-      const options = {
-        method: "GET",
-        url,
-        auth,
-      };
+    const getResponse = () => server.inject({ method: "GET", url, auth });
 
-      const res = await server.inject(options);
+    testBrowserPageTitle({ title: "Pig livestock genetic sequencing result", getResponse });
+    testPageHeading({ heading: "What was the result of the genetic sequencing?", getResponse });
+
+    test("returns 200", async () => {
+      const res = await getResponse();
 
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
-      expect($("h1").text()).toMatch(" What was the result of the genetic sequencing?");
-      expect($("title").text()).toContain(
-        "Pig livestock genetic sequencing result - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
-      );
-
       expectPhaseBanner.ok($);
     });
 

--- a/test/integration/narrow/routes/livestock/claim/pigs-genetic-sequencing.test.js
+++ b/test/integration/narrow/routes/livestock/claim/pigs-genetic-sequencing.test.js
@@ -13,6 +13,7 @@ import {
   testBrowserPageTitle,
   testPageHeading,
 } from "../../../../../helpers/page-title-and-heading.js";
+import { testRedirectsToSignInWhenLoggedOut } from "../../../../../helpers/sign-in-redirect.js";
 
 jest.mock("../../../../../../app/session/index.js");
 
@@ -75,16 +76,8 @@ describe("pigs genetic sequencing test", () => {
       expectPhaseBanner.ok($);
     });
 
-    test("when not logged in redirects to /sign-in", async () => {
-      const options = {
-        method: "GET",
-        url,
-      };
-
-      const res = await server.inject(options);
-
-      expect(res.statusCode).toBe(302);
-      expect(res.headers.location.toString()).toEqual(`/sign-in`);
+    testRedirectsToSignInWhenLoggedOut({
+      getResponse: () => server.inject({ method: "GET", url }),
     });
   });
 
@@ -99,18 +92,14 @@ describe("pigs genetic sequencing test", () => {
       jest.resetAllMocks();
     });
 
-    test("when not logged in redirects to /sign-in", async () => {
-      const options = {
-        method: "POST",
-        url,
-        payload: { crumb, geneticSequencing: "recomb" },
-        headers: { cookie: `crumb=${crumb}` },
-      };
-
-      const res = await server.inject(options);
-
-      expect(res.statusCode).toBe(302);
-      expect(res.headers.location.toString()).toEqual(`/sign-in`);
+    testRedirectsToSignInWhenLoggedOut({
+      getResponse: () =>
+        server.inject({
+          method: "POST",
+          url,
+          payload: { crumb, geneticSequencing: "recomb" },
+          headers: { cookie: `crumb=${crumb}` },
+        }),
     });
 
     test("shows error when payload is invalid", async () => {

--- a/test/integration/narrow/routes/livestock/claim/pigs-pcr-result.test.js
+++ b/test/integration/narrow/routes/livestock/claim/pigs-pcr-result.test.js
@@ -13,6 +13,7 @@ import {
   testBrowserPageTitle,
   testPageHeading,
 } from "../../../../../helpers/page-title-and-heading.js";
+import { testRedirectsToSignInWhenLoggedOut } from "../../../../../helpers/sign-in-redirect.js";
 
 jest.mock("../../../../../../app/session/index.js");
 
@@ -75,16 +76,8 @@ describe("pigs pcr result test", () => {
       expectPhaseBanner.ok($);
     });
 
-    test("when not logged in redirects to /sign-in", async () => {
-      const options = {
-        method: "GET",
-        url,
-      };
-
-      const res = await server.inject(options);
-
-      expect(res.statusCode).toBe(302);
-      expect(res.headers.location.toString()).toEqual(`/sign-in`);
+    testRedirectsToSignInWhenLoggedOut({
+      getResponse: () => server.inject({ method: "GET", url }),
     });
   });
 
@@ -96,18 +89,14 @@ describe("pigs pcr result test", () => {
       crumb = await getCrumbs(server);
     });
 
-    test("when not logged in redirects to /sign-in", async () => {
-      const options = {
-        method: "POST",
-        url,
-        payload: { crumb, pcrResult: "positive" },
-        headers: { cookie: `crumb=${crumb}` },
-      };
-
-      const res = await server.inject(options);
-
-      expect(res.statusCode).toBe(302);
-      expect(res.headers.location.toString()).toEqual(`/sign-in`);
+    testRedirectsToSignInWhenLoggedOut({
+      getResponse: () =>
+        server.inject({
+          method: "POST",
+          url,
+          payload: { crumb, pcrResult: "positive" },
+          headers: { cookie: `crumb=${crumb}` },
+        }),
     });
 
     test("shows error when payload is invalid", async () => {

--- a/test/integration/narrow/routes/livestock/claim/pigs-pcr-result.test.js
+++ b/test/integration/narrow/routes/livestock/claim/pigs-pcr-result.test.js
@@ -9,6 +9,10 @@ import {
 import expectPhaseBanner from "assert";
 import { getCrumbs } from "../../../../../utils/get-crumbs.js";
 import { when } from "jest-when";
+import {
+  testBrowserPageTitle,
+  testPageHeading,
+} from "../../../../../helpers/page-title-and-heading.js";
 
 jest.mock("../../../../../../app/session/index.js");
 
@@ -58,22 +62,16 @@ describe("pigs pcr result test", () => {
   });
 
   describe(`GET ${url} route`, () => {
-    test("returns 200", async () => {
-      const options = {
-        method: "GET",
-        url,
-        auth,
-      };
+    const getResponse = () => server.inject({ method: "GET", url, auth });
 
-      const res = await server.inject(options);
+    testBrowserPageTitle({ title: "Pig livestock PCR test-result", getResponse });
+    testPageHeading({ heading: "What was the result of the PCR test?", getResponse });
+
+    test("returns 200", async () => {
+      const res = await getResponse();
 
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
-      expect($("h1").text()).toMatch("What was the result of the PCR test?");
-      expect($("title").text()).toContain(
-        "Pig livestock PCR test-result - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
-      );
-
       expectPhaseBanner.ok($);
     });
 

--- a/test/integration/narrow/routes/livestock/claim/same-herd.test.js
+++ b/test/integration/narrow/routes/livestock/claim/same-herd.test.js
@@ -13,6 +13,7 @@ import { canMakeClaim } from "../../../../../../app/lib/can-make-claim.js";
 import { getReviewWithinLast10Months } from "../../../../../../app/lib/claim-helper.js";
 import { sendInvalidDataEvent } from "../../../../../../app/messaging/ineligibility-event-emission.js";
 import { when } from "jest-when";
+import { testBrowserPageTitle } from "../../../../../helpers/page-title-and-heading.js";
 
 jest.mock("../../../../../../app/session/index.js");
 jest.mock("../../../../../../app/api-requests/claim-api");
@@ -70,6 +71,34 @@ describe("select-the-herd tests", () => {
   });
 
   describe("GET", () => {
+    const getResponse = (session) => () => {
+      when(getSessionData)
+        .calledWith(expect.anything(), sessionEntryKeys.endemicsClaim)
+        .mockReturnValue(session);
+      return server.inject({ method: "GET", url, auth });
+    };
+
+    testBrowserPageTitle({
+      title: "Previous flock livestock claim",
+      getResponse: getResponse({
+        reference: "TEMP-6GSE-PIR8",
+        typeOfReview: "REVIEW",
+        typeOfLivestock: "sheep",
+        previousClaims: [],
+        herds: [],
+      }),
+    });
+    testBrowserPageTitle({
+      title: "Previous herd livestock claim",
+      getResponse: getResponse({
+        reference: "TEMP-6GSE-PIR8",
+        typeOfReview: "REVIEW",
+        typeOfLivestock: "beef",
+        previousClaims: [],
+        herds: [],
+      }),
+    });
+
     test("returns 200 with flock labels when species sheep and display type value from previousClaims", async () => {
       when(getSessionData)
         .calledWith(expect.anything(), sessionEntryKeys.endemicsClaim)
@@ -109,9 +138,6 @@ describe("select-the-herd tests", () => {
 
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
-      expect($("title").text().trim()).toContain(
-        "Previous flock livestock claim - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
-      );
       expect($(".govuk-back-link").attr("href")).toContain("/livestock/check-herd-details");
       expectPhaseBanner.ok($);
 
@@ -140,9 +166,6 @@ describe("select-the-herd tests", () => {
 
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
-      expect($("title").text().trim()).toContain(
-        "Previous herd livestock claim - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
-      );
       expect($(".govuk-back-link").attr("href")).toContain("/livestock/check-herd-details");
       expect($('.govuk-radios__input[value="yes"]').is(":checked")).toBeTruthy();
       expectPhaseBanner.ok($);

--- a/test/integration/narrow/routes/livestock/claim/select-the-herd.test.js
+++ b/test/integration/narrow/routes/livestock/claim/select-the-herd.test.js
@@ -11,6 +11,7 @@ import {
 } from "../../../../../../app/session/index.js";
 import { canMakeClaim } from "../../../../../../app/lib/can-make-claim.js";
 import { when } from "jest-when";
+import { testBrowserPageTitle } from "../../../../../helpers/page-title-and-heading.js";
 import { sendInvalidDataEvent } from "../../../../../../app/messaging/ineligibility-event-emission.js";
 
 jest.mock("../../../../../../app/session/index.js");
@@ -71,6 +72,50 @@ describe("select-the-herd tests", () => {
   });
 
   describe("GET", () => {
+    const getResponse = (session) => () => {
+      when(getSessionData)
+        .calledWith(expect.anything(), sessionEntryKeys.endemicsClaim)
+        .mockReturnValue(session);
+      return server.inject({ method: "GET", url, auth });
+    };
+
+    testBrowserPageTitle({
+      title: "Is this the same livestock flock you have previously claimed for?",
+      getResponse: getResponse({
+        reference: "TEMP-6GSE-PIR8",
+        typeOfReview: "REVIEW",
+        typeOfLivestock: "sheep",
+        previousClaims: [],
+        herds: [],
+      }),
+    });
+
+    testBrowserPageTitle({
+      title: "Is this the same livestock herd you have previously claimed for?",
+      getResponse: getResponse({
+        reference: "TEMP-6GSE-PIR8",
+        typeOfReview: "REVIEW",
+        typeOfLivestock: "beef",
+        previousClaims: [],
+        herds: [{ id: "100bb722-3de1-443e-8304-0bba8f922050", name: "Barn animals" }],
+      }),
+    });
+
+    testBrowserPageTitle({
+      title: "Livestock herd you are claiming for",
+      getResponse: getResponse({
+        reference: "TEMP-6GSE-PIR8",
+        typeOfReview: "REVIEW",
+        typeOfLivestock: "beef",
+        previousClaims: [],
+        herds: [
+          { id: "100bb722-3de1-443e-8304-0bba8f922050", name: "Barn animals" },
+          { id: "200bb722-3de1-443e-8304-0bba8f922050", name: "Hilltop" },
+          { id: "300bb722-3de1-443e-8304-0bba8f922050", name: "Field animals" },
+        ],
+      }),
+    });
+
     test("returns 200 with flock labels when species sheep", async () => {
       when(getSessionData)
         .calledWith(expect.anything(), sessionEntryKeys.endemicsClaim)
@@ -107,9 +152,6 @@ describe("select-the-herd tests", () => {
 
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
-      expect($("title").text().trim()).toContain(
-        "Is this the same livestock flock you have previously claimed for? - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
-      );
       expect($(".govuk-back-link").attr("href")).toContain("/livestock/date-of-visit");
       expectPhaseBanner.ok($);
     });
@@ -132,9 +174,6 @@ describe("select-the-herd tests", () => {
 
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
-      expect($("title").text().trim()).toContain(
-        "Is this the same livestock herd you have previously claimed for? - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
-      );
       expect($(".govuk-back-link").attr("href")).toContain("/livestock/date-of-visit");
       expect($('.govuk-radios__input[value="NEW_HERD"]').is(":checked")).toBeTruthy();
       expectPhaseBanner.ok($);
@@ -171,9 +210,6 @@ describe("select-the-herd tests", () => {
 
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
-      expect($("title").text().trim()).toContain(
-        "Livestock herd you are claiming for - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
-      );
       expectPhaseBanner.ok($);
 
       const radios = $(".govuk-radios__item");
@@ -220,9 +256,6 @@ describe("select-the-herd tests", () => {
 
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
-      expect($("title").text().trim()).toContain(
-        "Is this the same livestock flock you have previously claimed for? - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
-      );
       expect($(".govuk-back-link").attr("href")).toContain("/livestock/date-of-visit");
       expectPhaseBanner.ok($);
 
@@ -295,9 +328,6 @@ describe("select-the-herd tests", () => {
 
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
-      expect($("title").text().trim()).toContain(
-        "Livestock herd you are claiming for - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
-      );
       expectPhaseBanner.ok($);
 
       const radios = $(".govuk-radios__item");
@@ -383,9 +413,6 @@ describe("select-the-herd tests", () => {
 
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
-      expect($("title").text().trim()).toContain(
-        "Livestock herd you are claiming for - Get funding to improve animal health and welfare - GOV.UKGOV.UK",
-      );
       expectPhaseBanner.ok($);
 
       const radios = $(".govuk-radios__item");

--- a/test/integration/narrow/routes/livestock/claim/sheep-test-results.test.js
+++ b/test/integration/narrow/routes/livestock/claim/sheep-test-results.test.js
@@ -8,6 +8,7 @@ import {
   setSessionData,
 } from "../../../../../../app/session/index.js";
 import { when } from "jest-when";
+import { testBrowserPageTitle } from "../../../../../helpers/page-title-and-heading.js";
 
 jest.mock("../../../../../../app/session/index.js");
 
@@ -57,6 +58,26 @@ describe("Sheep test result tests", () => {
   });
 
   describe(`GET ${url} route`, () => {
+    const getResponse = () => {
+      when(getSessionData)
+        .calledWith(expect.anything(), sessionEntryKeys.endemicsClaim)
+        .mockReturnValue({
+          typeOfLivestock: "sheep",
+          sheepEndemicsPackage: "reducedExternalParasites",
+          sheepTestResults: [
+            ...sheepTestResultsMockData,
+            { diseaseType: "sheepScab", result: "", isCurrentPage: true },
+          ],
+          reference: "TEMP-6GSE-PIR8",
+        });
+      return server.inject({ method: "GET", url: `${url}?diseaseType=sheepScab`, auth });
+    };
+
+    testBrowserPageTitle({
+      title: "Sheep livestock test result",
+      getResponse,
+    });
+
     test(`Get ${url} Returns 200`, async () => {
       const options = {
         method: "GET",
@@ -81,7 +102,6 @@ describe("Sheep test result tests", () => {
 
       expect(res.statusCode).toBe(200);
       expect($("h1").text()).toMatch("What was the Sheep scab result?");
-      expect($("title").text()).toContain("Sheep livestock test result");
       expect($(".govuk-back-link").attr("href")).toContain(
         "/livestock/sheep-test-results?diseaseType=other",
       );

--- a/test/integration/narrow/routes/livestock/claim/sheep-tests.test.js
+++ b/test/integration/narrow/routes/livestock/claim/sheep-tests.test.js
@@ -9,6 +9,10 @@ import {
   setSessionData,
 } from "../../../../../../app/session/index.js";
 import { when } from "jest-when";
+import {
+  testBrowserPageTitle,
+  testPageHeading,
+} from "../../../../../helpers/page-title-and-heading.js";
 
 jest.mock("../../../../../../app/session/index.js");
 
@@ -34,6 +38,46 @@ describe("Test Results test", () => {
   });
 
   describe(`GET ${url} route`, () => {
+    const getResponse = () => {
+      when(getSessionData)
+        .calledWith(expect.anything(), sessionEntryKeys.endemicsClaim)
+        .mockReturnValue({
+          sheepEndemicsPackage: "reducedExternalParasites",
+          reference: "TEMP-6GSE-PIR8",
+        });
+      when(getSessionData)
+        .calledWith(
+          expect.anything(),
+          sessionEntryKeys.endemicsClaim,
+          sessionKeys.endemicsClaim.latestEndemicsApplication,
+        )
+        .mockReturnValue({ status: "AGREED" });
+      when(getSessionData)
+        .calledWith(
+          expect.anything(),
+          sessionEntryKeys.confirmedDetails,
+          sessionKeys.confirmedDetails,
+        )
+        .mockReturnValue(true);
+      when(getSessionData)
+        .calledWith(
+          expect.anything(),
+          sessionEntryKeys.endemicsClaim,
+          sessionKeys.endemicsClaim.reference,
+        )
+        .mockReturnValue("IAHW-1LZ5-ELVQ");
+      return server.inject({ method: "GET", url, auth });
+    };
+
+    testBrowserPageTitle({
+      title: "Sheep livestock disease or condition samples",
+      getResponse,
+    });
+    testPageHeading({
+      heading: "Which disease or condition did the vet take samples to test for?",
+      getResponse,
+    });
+
     test("returns 200", async () => {
       when(getSessionData)
         .calledWith(expect.anything(), sessionEntryKeys.endemicsClaim)
@@ -76,12 +120,6 @@ describe("Test Results test", () => {
       const $ = cheerio.load(res.payload);
 
       expect(res.statusCode).toBe(200);
-      expect($("h1").text()).toMatch(
-        "Which disease or condition did the vet take samples to test for?",
-      );
-      expect($("title").text()).toMatch(
-        "Sheep livestock disease or condition samples - Get funding to improve animal health and welfare",
-      );
       expect($(".govuk-back-link").attr("href")).toContain("/livestock/sheep-endemics-package");
 
       expectPhaseBanner.ok($);

--- a/test/integration/narrow/routes/livestock/claim/test-results.test.js
+++ b/test/integration/narrow/routes/livestock/claim/test-results.test.js
@@ -9,6 +9,10 @@ import {
   setSessionData,
 } from "../../../../../../app/session/index.js";
 import { when } from "jest-when";
+import {
+  testBrowserPageTitle,
+  testPageHeading,
+} from "../../../../../helpers/page-title-and-heading.js";
 
 jest.mock("../../../../../../app/session/index.js");
 
@@ -58,32 +62,26 @@ describe("Test Results test", () => {
   });
 
   describe(`GET ${url} route`, () => {
-    test.each([
-      { typeOfReview: "FOLLOW_UP", question: "What was the follow-up test result?" },
-      { typeOfReview: "REVIEW", question: "What was the test result?" },
-    ])("returns 200", async ({ typeOfReview, question }) => {
+    const getResponse = (typeOfReview) => () => {
       when(getSessionData)
         .calledWith(expect.anything(), sessionEntryKeys.endemicsClaim)
         .mockImplementation(() => {
           return { typeOfReview, reference: "TEMP-6GSE-PIR8" };
         });
+      return server.inject({ method: "GET", url, auth });
+    };
 
-      const options = {
-        method: "GET",
-        url,
-        auth,
-      };
-
-      const res = await server.inject(options);
-
-      expect(res.statusCode).toBe(200);
-      const $ = cheerio.load(res.payload);
-      expect($("h1").text()).toMatch(question);
-      expect($("title").text()).toContain(
-        "Livestock test result - Get funding to improve animal health and welfare",
-      );
-
-      expectPhaseBanner.ok($);
+    testBrowserPageTitle({
+      title: "Livestock test result",
+      getResponse: getResponse("REVIEW"),
+    });
+    testPageHeading({
+      heading: "What was the test result?",
+      getResponse: getResponse("REVIEW"),
+    });
+    testPageHeading({
+      heading: "What was the follow-up test result?",
+      getResponse: getResponse("FOLLOW_UP"),
     });
 
     test.each([

--- a/test/integration/narrow/routes/livestock/claim/test-results.test.js
+++ b/test/integration/narrow/routes/livestock/claim/test-results.test.js
@@ -13,6 +13,7 @@ import {
   testBrowserPageTitle,
   testPageHeading,
 } from "../../../../../helpers/page-title-and-heading.js";
+import { testRedirectsToSignInWhenLoggedOut } from "../../../../../helpers/sign-in-redirect.js";
 
 jest.mock("../../../../../../app/session/index.js");
 
@@ -142,16 +143,8 @@ describe("Test Results test", () => {
       expectPhaseBanner.ok($);
     });
 
-    test("when not logged in redirects to /sign-in", async () => {
-      const options = {
-        method: "GET",
-        url,
-      };
-
-      const res = await server.inject(options);
-
-      expect(res.statusCode).toBe(302);
-      expect(res.headers.location.toString()).toEqual(`/sign-in`);
+    testRedirectsToSignInWhenLoggedOut({
+      getResponse: () => server.inject({ method: "GET", url }),
     });
   });
 
@@ -162,18 +155,14 @@ describe("Test Results test", () => {
       crumb = await getCrumbs(server);
     });
 
-    test("when not logged in redirects to /sign-in", async () => {
-      const options = {
-        method: "POST",
-        url,
-        payload: { crumb, testResults: "positive" },
-        headers: { cookie: `crumb=${crumb}` },
-      };
-
-      const res = await server.inject(options);
-
-      expect(res.statusCode).toBe(302);
-      expect(res.headers.location.toString()).toEqual(`/sign-in`);
+    testRedirectsToSignInWhenLoggedOut({
+      getResponse: () =>
+        server.inject({
+          method: "POST",
+          url,
+          payload: { crumb, testResults: "positive" },
+          headers: { cookie: `crumb=${crumb}` },
+        }),
     });
 
     test.each([

--- a/test/integration/narrow/routes/livestock/claim/test-urn.test.js
+++ b/test/integration/narrow/routes/livestock/claim/test-urn.test.js
@@ -14,6 +14,10 @@ import {
   setSessionData,
 } from "../../../../../../app/session/index.js";
 import { when } from "jest-when";
+import {
+  testBrowserPageTitle,
+  testPageHeading,
+} from "../../../../../helpers/page-title-and-heading.js";
 import { sendInvalidDataEvent } from "../../../../../../app/messaging/ineligibility-event-emission.js";
 
 jest.mock("../../../../../../app/session/index.js");
@@ -68,61 +72,30 @@ describe("Test URN GET", () => {
   });
 
   describe(`GET ${url} route`, () => {
-    test.each([
-      {
-        typeOfLivestock: "beef",
-        typeOfReview: "FOLLOW_UP",
-        title:
-          "What’s the laboratory unique reference number (URN) or certificate number of the test results?",
-        reviewTestResults: "positive",
-      },
-      {
-        typeOfLivestock: "dairy",
-        typeOfReview: "FOLLOW_UP",
-        title:
-          "What’s the laboratory unique reference number (URN) or certificate number of the test results?",
-      },
-      {
-        typeOfLivestock: "sheep",
-        typeOfReview: "REVIEW",
-        title: "What’s the laboratory unique reference number (URN) for the test results?",
-      },
-      {
-        typeOfLivestock: "pigs",
-        typeOfReview: "FOLLOW_UP",
-        title: "What’s the laboratory unique reference number (URN) for the test results?",
-      },
-    ])(
-      "Return 200 with Title $title when type of species is $typeOfLivestock and type of review is $typeOfReview",
-      async ({ title, typeOfLivestock, typeOfReview, reviewTestResults }) => {
-        when(getSessionData)
-          .calledWith(expect.anything(), sessionEntryKeys.endemicsClaim)
-          .mockReturnValue({
-            typeOfLivestock,
-            typeOfReview,
-            reviewTestResults,
-            reference: "TEMP-6GSE-PIR8",
-            laboratoryURN: "ABC123",
-          });
+    const getResponse = (session) => () => {
+      when(getSessionData)
+        .calledWith(expect.anything(), sessionEntryKeys.endemicsClaim)
+        .mockReturnValue({
+          reference: "TEMP-6GSE-PIR8",
+          laboratoryURN: "ABC123",
+          ...session,
+        });
+      return server.inject({ method: "GET", url, auth });
+    };
 
-        const options = {
-          method: "GET",
-          url,
-          auth,
-        };
-
-        const res = await server.inject(options);
-
-        expect(res.statusCode).toBe(200);
-        const $ = cheerio.load(res.payload);
-        expect($("h1").text()).toMatch(title);
-        expect($("title").text()).toContain(
-          "Livestock laboratory's unique reference number - Get funding to improve animal health and welfare",
-        );
-
-        expectPhaseBanner.ok($);
-      },
-    );
+    testBrowserPageTitle({
+      title: "Livestock laboratory's unique reference number",
+      getResponse: getResponse({ typeOfLivestock: "beef", typeOfReview: "FOLLOW_UP" }),
+    });
+    testPageHeading({
+      heading:
+        "What’s the laboratory unique reference number (URN) or certificate number of the test results?",
+      getResponse: getResponse({ typeOfLivestock: "beef", typeOfReview: "FOLLOW_UP" }),
+    });
+    testPageHeading({
+      heading: "What’s the laboratory unique reference number (URN) for the test results?",
+      getResponse: getResponse({ typeOfLivestock: "sheep", typeOfReview: "REVIEW" }),
+    });
 
     test.each([
       {

--- a/test/integration/narrow/routes/livestock/claim/test-urn.test.js
+++ b/test/integration/narrow/routes/livestock/claim/test-urn.test.js
@@ -18,6 +18,7 @@ import {
   testBrowserPageTitle,
   testPageHeading,
 } from "../../../../../helpers/page-title-and-heading.js";
+import { testRedirectsToSignInWhenLoggedOut } from "../../../../../helpers/sign-in-redirect.js";
 import { sendInvalidDataEvent } from "../../../../../../app/messaging/ineligibility-event-emission.js";
 
 jest.mock("../../../../../../app/session/index.js");
@@ -210,16 +211,8 @@ describe("Test URN GET", () => {
       },
     );
 
-    test("when not logged in redirects to /sign-in", async () => {
-      const options = {
-        method: "GET",
-        url,
-      };
-
-      const res = await server.inject(options);
-
-      expect(res.statusCode).toBe(302);
-      expect(res.headers.location.toString()).toEqual(`/sign-in`);
+    testRedirectsToSignInWhenLoggedOut({
+      getResponse: () => server.inject({ method: "GET", url }),
     });
   });
 
@@ -230,18 +223,14 @@ describe("Test URN GET", () => {
       crumb = await getCrumbs(server);
     });
 
-    test("when not logged in redirects to /sign-in", async () => {
-      const options = {
-        method: "POST",
-        url,
-        payload: { crumb, laboratoryURN: "123" },
-        headers: { cookie: `crumb=${crumb}` },
-      };
-
-      const res = await server.inject(options);
-
-      expect(res.statusCode).toBe(302);
-      expect(res.headers.location.toString()).toEqual(`/sign-in`);
+    testRedirectsToSignInWhenLoggedOut({
+      getResponse: () =>
+        server.inject({
+          method: "POST",
+          url,
+          payload: { crumb, laboratoryURN: "123" },
+          headers: { cookie: `crumb=${crumb}` },
+        }),
     });
 
     test.each([

--- a/test/integration/narrow/routes/livestock/claim/type-of-samples-taken.test.js
+++ b/test/integration/narrow/routes/livestock/claim/type-of-samples-taken.test.js
@@ -14,6 +14,7 @@ import {
   testBrowserPageTitle,
   testPageHeading,
 } from "../../../../../helpers/page-title-and-heading.js";
+import { testRedirectsToSignInWhenLoggedOut } from "../../../../../helpers/sign-in-redirect.js";
 
 jest.mock("../../../../../../app/messaging/ineligibility-event-emission.js");
 jest.mock("../../../../../../app/session/index.js");
@@ -78,16 +79,8 @@ describe("Type of samples taken test", () => {
       expectPhaseBanner.ok($);
     });
 
-    test("when not logged in redirects to /sign-in", async () => {
-      const options = {
-        method: "GET",
-        url,
-      };
-
-      const res = await server.inject(options);
-
-      expect(res.statusCode).toBe(302);
-      expect(res.headers.location.toString()).toEqual("/sign-in");
+    testRedirectsToSignInWhenLoggedOut({
+      getResponse: () => server.inject({ method: "GET", url }),
     });
   });
 
@@ -98,18 +91,14 @@ describe("Type of samples taken test", () => {
       crumb = await getCrumbs(server);
     });
 
-    test("when not logged in redirects to /sign-in", async () => {
-      const options = {
-        method: "POST",
-        url,
-        payload: { crumb, typeOfSamplesTaken: "blood" },
-        headers: { cookie: `crumb=${crumb}` },
-      };
-
-      const res = await server.inject(options);
-
-      expect(res.statusCode).toBe(302);
-      expect(res.headers.location.toString()).toEqual("/sign-in");
+    testRedirectsToSignInWhenLoggedOut({
+      getResponse: () =>
+        server.inject({
+          method: "POST",
+          url,
+          payload: { crumb, typeOfSamplesTaken: "blood" },
+          headers: { cookie: `crumb=${crumb}` },
+        }),
     });
 
     test("shows error when payload is invalid", async () => {

--- a/test/integration/narrow/routes/livestock/claim/type-of-samples-taken.test.js
+++ b/test/integration/narrow/routes/livestock/claim/type-of-samples-taken.test.js
@@ -10,6 +10,10 @@ import {
 import expectPhaseBanner from "assert";
 import { getCrumbs } from "../../../../../utils/get-crumbs.js";
 import { when } from "jest-when";
+import {
+  testBrowserPageTitle,
+  testPageHeading,
+} from "../../../../../helpers/page-title-and-heading.js";
 
 jest.mock("../../../../../../app/messaging/ineligibility-event-emission.js");
 jest.mock("../../../../../../app/session/index.js");
@@ -61,21 +65,16 @@ describe("Type of samples taken test", () => {
   });
 
   describe(`GET ${url} route`, () => {
-    test("returns 200", async () => {
-      const options = {
-        method: "GET",
-        url,
-        auth,
-      };
+    const getResponse = () => server.inject({ method: "GET", url, auth });
 
-      const res = await server.inject(options);
+    testBrowserPageTitle({ title: "Type of livestock samples", getResponse });
+    testPageHeading({ heading: "What type of samples were taken?", getResponse });
+
+    test("returns 200", async () => {
+      const res = await getResponse();
 
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
-      expect($("h1").text()).toMatch("What type of samples were taken?");
-      expect($("title").text()).toContain(
-        "Type of livestock samples - Get funding to improve animal health and welfare",
-      );
       expectPhaseBanner.ok($);
     });
 

--- a/test/integration/narrow/routes/livestock/claim/vaccination.test.js
+++ b/test/integration/narrow/routes/livestock/claim/vaccination.test.js
@@ -9,6 +9,10 @@ import {
   setSessionData,
 } from "../../../../../../app/session/index.js";
 import { when } from "jest-when";
+import {
+  testBrowserPageTitle,
+  testPageHeading,
+} from "../../../../../helpers/page-title-and-heading.js";
 
 jest.mock("../../../../../../app/session/index.js");
 
@@ -58,23 +62,20 @@ describe("Vaccination test", () => {
   });
 
   describe(`GET ${url} route`, () => {
-    test("Returns 200", async () => {
-      const options = {
-        method: "GET",
-        url,
-        auth,
-      };
+    const getResponse = () => server.inject({ method: "GET", url, auth });
 
-      const res = await server.inject(options);
+    testBrowserPageTitle({ title: "Livestock vaccination", getResponse });
+    testPageHeading({
+      heading:
+        "What is the herd porcine reproductive and respiratory syndrome (PRRS) vaccination status?",
+      getResponse,
+    });
+
+    test("Returns 200", async () => {
+      const res = await getResponse();
 
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
-      expect($("title").text()).toContain(
-        "Livestock vaccination - Get funding to improve animal health and welfare",
-      );
-      expect($("h1").text()).toMatch(
-        "What is the herd porcine reproductive and respiratory syndrome (PRRS) vaccination status?",
-      );
       expectPhaseBanner.ok($);
     });
 

--- a/test/integration/narrow/routes/livestock/claim/vaccination.test.js
+++ b/test/integration/narrow/routes/livestock/claim/vaccination.test.js
@@ -13,6 +13,7 @@ import {
   testBrowserPageTitle,
   testPageHeading,
 } from "../../../../../helpers/page-title-and-heading.js";
+import { testRedirectsToSignInWhenLoggedOut } from "../../../../../helpers/sign-in-redirect.js";
 
 jest.mock("../../../../../../app/session/index.js");
 
@@ -79,16 +80,8 @@ describe("Vaccination test", () => {
       expectPhaseBanner.ok($);
     });
 
-    test("when not logged in redirects to /sign-in", async () => {
-      const options = {
-        method: "GET",
-        url,
-      };
-
-      const res = await server.inject(options);
-
-      expect(res.statusCode).toBe(302);
-      expect(res.headers.location.toString()).toEqual(`/sign-in`);
+    testRedirectsToSignInWhenLoggedOut({
+      getResponse: () => server.inject({ method: "GET", url }),
     });
 
     test.each([
@@ -149,18 +142,14 @@ describe("Vaccination test", () => {
       crumb = await getCrumbs(server);
     });
 
-    test("when not logged in redirects to /sign-in", async () => {
-      const options = {
-        method: "POST",
-        url,
-        payload: { crumb, herdVaccinationStatus: "vaccinated" },
-        headers: { cookie: `crumb=${crumb}` },
-      };
-
-      const res = await server.inject(options);
-
-      expect(res.statusCode).toBe(302);
-      expect(res.headers.location.toString()).toEqual(`/sign-in`);
+    testRedirectsToSignInWhenLoggedOut({
+      getResponse: () =>
+        server.inject({
+          method: "POST",
+          url,
+          payload: { crumb, herdVaccinationStatus: "vaccinated" },
+          headers: { cookie: `crumb=${crumb}` },
+        }),
     });
 
     test.each([

--- a/test/integration/narrow/routes/livestock/claim/vet-name.test.js
+++ b/test/integration/narrow/routes/livestock/claim/vet-name.test.js
@@ -9,6 +9,10 @@ import {
   setSessionData,
 } from "../../../../../../app/session/index.js";
 import { when } from "jest-when";
+import {
+  testBrowserPageTitle,
+  testPageHeading,
+} from "../../../../../helpers/page-title-and-heading.js";
 
 const errorMessages = {
   enterName: "Enter the vet's name",
@@ -68,6 +72,20 @@ describe("Vet name test", () => {
   });
 
   describe(`GET ${url} route`, () => {
+    const getResponse = () => {
+      when(getSessionData)
+        .calledWith(expect.anything(), sessionEntryKeys.endemicsClaim)
+        .mockReturnValue({
+          typeOfLivestock: "beef",
+          typeOfReview: "FOLLOW_UP",
+          reference: "TEMP-6GSE-PIR8",
+        });
+      return server.inject({ method: "GET", url, auth });
+    };
+
+    testBrowserPageTitle({ title: "Livestock vet's name", getResponse });
+    testPageHeading({ heading: "What is the vet's name?", getResponse });
+
     test.each([{ reviewTestResults: "negative" }, { reviewTestResults: "positive" }])(
       "returns 200",
       async ({ reviewTestResults }) => {
@@ -79,20 +97,11 @@ describe("Vet name test", () => {
             reviewTestResults,
             reference: "TEMP-6GSE-PIR8",
           });
-        const options = {
-          method: "GET",
-          url,
-          auth,
-        };
 
-        const res = await server.inject(options);
+        const res = await server.inject({ method: "GET", url, auth });
 
         expect(res.statusCode).toBe(200);
         const $ = cheerio.load(res.payload);
-        expect($("h1").text()).toMatch("What is the vet's name?");
-        expect($("title").text().trim()).toContain(
-          "Livestock vet's name - Get funding to improve animal health and welfare",
-        );
         expectPhaseBanner.ok($);
       },
     );

--- a/test/integration/narrow/routes/livestock/claim/vet-name.test.js
+++ b/test/integration/narrow/routes/livestock/claim/vet-name.test.js
@@ -13,6 +13,7 @@ import {
   testBrowserPageTitle,
   testPageHeading,
 } from "../../../../../helpers/page-title-and-heading.js";
+import { testRedirectsToSignInWhenLoggedOut } from "../../../../../helpers/sign-in-redirect.js";
 
 const errorMessages = {
   enterName: "Enter the vet's name",
@@ -106,16 +107,8 @@ describe("Vet name test", () => {
       },
     );
 
-    test("when not logged in redirects to /sign-in", async () => {
-      const options = {
-        method: "GET",
-        url,
-      };
-
-      const res = await server.inject(options);
-
-      expect(res.statusCode).toBe(302);
-      expect(res.headers.location.toString()).toEqual(`/sign-in`);
+    testRedirectsToSignInWhenLoggedOut({
+      getResponse: () => server.inject({ method: "GET", url }),
     });
   });
 
@@ -126,18 +119,14 @@ describe("Vet name test", () => {
       crumb = await getCrumbs(server);
     });
 
-    test("when not logged in redirects to /sign-in", async () => {
-      const options = {
-        method: "POST",
-        url,
-        payload: { crumb, numberAnimalsTested: "123" },
-        headers: { cookie: `crumb=${crumb}` },
-      };
-
-      const res = await server.inject(options);
-
-      expect(res.statusCode).toBe(302);
-      expect(res.headers.location.toString()).toEqual(`/sign-in`);
+    testRedirectsToSignInWhenLoggedOut({
+      getResponse: () =>
+        server.inject({
+          method: "POST",
+          url,
+          payload: { crumb, numberAnimalsTested: "123" },
+          headers: { cookie: `crumb=${crumb}` },
+        }),
     });
     test.each([
       { vetsName: "", error: errorMessages.enterName },

--- a/test/integration/narrow/routes/livestock/claim/vet-rcvs.test.js
+++ b/test/integration/narrow/routes/livestock/claim/vet-rcvs.test.js
@@ -10,6 +10,10 @@ import {
   setSessionData,
 } from "../../../../../../app/session/index.js";
 import { when } from "jest-when";
+import {
+  testBrowserPageTitle,
+  testPageHeading,
+} from "../../../../../helpers/page-title-and-heading.js";
 
 jest.mock("../../../../../../app/session/index.js");
 jest.mock("../../../../../../app/lib/context-helper.js");
@@ -67,23 +71,19 @@ describe("Vet rcvs test when Optional PI Hunt is OFF", () => {
   });
 
   describe(`GET ${url} route`, () => {
-    test("returns 200", async () => {
-      const options = {
-        method: "GET",
-        url,
-        auth,
-      };
+    const getResponse = () => server.inject({ method: "GET", url, auth });
 
-      const res = await server.inject(options);
+    testBrowserPageTitle({ title: "Livestock vet's RCVS number", getResponse });
+    testPageHeading({
+      heading: "What is the vet's Royal College of Veterinary Surgeons (RCVS) number?",
+      getResponse,
+    });
+
+    test("returns 200", async () => {
+      const res = await getResponse();
 
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
-      expect($("h1 > label").text().trim()).toMatch(
-        "What is the vet's Royal College of Veterinary Surgeons (RCVS) number?",
-      );
-      expect($("title").text().trim()).toContain(
-        "Livestock vet's RCVS number - Get funding to improve animal health and welfare",
-      );
       expectPhaseBanner.ok($);
     });
 

--- a/test/integration/narrow/routes/livestock/claim/vet-rcvs.test.js
+++ b/test/integration/narrow/routes/livestock/claim/vet-rcvs.test.js
@@ -14,6 +14,7 @@ import {
   testBrowserPageTitle,
   testPageHeading,
 } from "../../../../../helpers/page-title-and-heading.js";
+import { testRedirectsToSignInWhenLoggedOut } from "../../../../../helpers/sign-in-redirect.js";
 
 jest.mock("../../../../../../app/session/index.js");
 jest.mock("../../../../../../app/lib/context-helper.js");
@@ -87,16 +88,8 @@ describe("Vet rcvs test when Optional PI Hunt is OFF", () => {
       expectPhaseBanner.ok($);
     });
 
-    test("when not logged in redirects to /sign-in", async () => {
-      const options = {
-        method: "GET",
-        url,
-      };
-
-      const res = await server.inject(options);
-
-      expect(res.statusCode).toBe(302);
-      expect(res.headers.location.toString()).toEqual(`/sign-in`);
+    testRedirectsToSignInWhenLoggedOut({
+      getResponse: () => server.inject({ method: "GET", url }),
     });
   });
 
@@ -107,18 +100,14 @@ describe("Vet rcvs test when Optional PI Hunt is OFF", () => {
       crumb = await getCrumbs(server);
     });
 
-    test("when not logged in redirects to /sign-in", async () => {
-      const options = {
-        method: "POST",
-        url,
-        payload: { crumb, vetRCVSNumber: "123" },
-        headers: { cookie: `crumb=${crumb}` },
-      };
-
-      const res = await server.inject(options);
-
-      expect(res.statusCode).toBe(302);
-      expect(res.headers.location.toString()).toEqual(`/sign-in`);
+    testRedirectsToSignInWhenLoggedOut({
+      getResponse: () =>
+        server.inject({
+          method: "POST",
+          url,
+          payload: { crumb, vetRCVSNumber: "123" },
+          headers: { cookie: `crumb=${crumb}` },
+        }),
     });
 
     test.each([

--- a/test/integration/narrow/routes/livestock/claim/which-species.test.js
+++ b/test/integration/narrow/routes/livestock/claim/which-species.test.js
@@ -12,6 +12,10 @@ import {
   setSessionData,
 } from "../../../../../../app/session/index.js";
 import { when } from "jest-when";
+import {
+  testBrowserPageTitle,
+  testPageHeading,
+} from "../../../../../helpers/page-title-and-heading.js";
 
 jest.mock("../../../../../../app/session");
 jest.mock("../../../../../../app/lib/context-helper", () => ({
@@ -77,21 +81,19 @@ describe("Endemics which species test", () => {
   });
 
   describe("GET /livestock/species", () => {
-    test("should render page when no previous session exists", async () => {
-      const options = {
-        method: "GET",
-        auth,
-        url,
-      };
+    const getResponse = () => server.inject({ method: "GET", auth, url });
 
-      const res = await server.inject(options);
+    testBrowserPageTitle({
+      title: "Which livestock species are you claiming for?",
+      getResponse,
+    });
+    testPageHeading({ heading: "Which species are you claiming for?", getResponse });
+
+    test("should render page when no previous session exists", async () => {
+      const res = await getResponse();
       const $ = cheerio.load(res.payload);
 
       expect(res.statusCode).toBe(200);
-      expect($("title").text().trim()).toContain(
-        "Which livestock species are you claiming for? - Get funding to improve animal health and welfare - GOV.UK",
-      );
-      expect($("h1").text().trim()).toMatch("Which species are you claiming for?");
       expect($(".govuk-radios__item").length).toEqual(4);
       expect($(".govuk-back-link").attr("href")).toContain("manage-claims");
 

--- a/test/integration/narrow/routes/livestock/claim/which-type-of-review.test.js
+++ b/test/integration/narrow/routes/livestock/claim/which-type-of-review.test.js
@@ -10,6 +10,10 @@ import {
 } from "../../../../../../app/session/index.js";
 import { sendInvalidDataEvent } from "../../../../../../app/messaging/ineligibility-event-emission.js";
 import { when } from "jest-when";
+import {
+  testBrowserPageTitle,
+  testPageHeading,
+} from "../../../../../helpers/page-title-and-heading.js";
 
 jest.mock("../../../../../../app/session");
 jest.mock("../../../../../../app/messaging/ineligibility-event-emission.js");
@@ -74,7 +78,7 @@ describe("Which type of review test", () => {
         .mockReturnValue({ typeOfReview: "REVIEW", reference: "TEMP-6GSE-PIR8" });
     });
 
-    test("returns 200 and renders page", async () => {
+    const getResponse = () => {
       when(getSessionData)
         .calledWith(expect.anything(), sessionEntryKeys.endemicsClaim)
         .mockReturnValue({
@@ -83,19 +87,23 @@ describe("Which type of review test", () => {
           previousClaims: [],
           latestVetVisitApplication,
         });
-      const options = {
-        method: "GET",
-        url,
-        auth,
-      };
+      return server.inject({ method: "GET", url, auth });
+    };
 
-      const res = await server.inject(options);
+    testBrowserPageTitle({
+      title: "Are you claiming for a livestock review or follow-up?",
+      getResponse,
+    });
+    testPageHeading({
+      heading: "Are you claiming for a review or follow-up?",
+      getResponse,
+    });
+
+    test("returns 200 and renders page", async () => {
+      const res = await getResponse();
 
       expect(res.statusCode).toBe(200);
       const $ = cheerio.load(res.payload);
-      expect($("title").text().trim()).toContain(
-        "Are you claiming for a livestock review or follow-up? - Get funding to improve animal health and welfare",
-      );
       expect($(".govuk-back-link").attr("href")).toContain("/livestock/species");
       expectPhaseBanner.ok($);
     });

--- a/test/integration/narrow/routes/livestock/vet-visits.test.js
+++ b/test/integration/narrow/routes/livestock/vet-visits.test.js
@@ -5,6 +5,7 @@ import { createServer } from "../../../../../app/server.js";
 import { getClaimsByApplicationReference } from "../../../../../app/api-requests/claim-api.js";
 import { refreshApplications } from "../../../../../app/lib/context-helper.js";
 import { axe } from "../../../../helpers/axe-helper.js";
+import { testBrowserPageTitle } from "../../../../helpers/page-title-and-heading.js";
 
 const nunJucksInternalTimerMethods = ["nextTick"];
 
@@ -106,6 +107,33 @@ describe("GET /livestock/manage-claims", () => {
   });
 
   describe("Cattle/Pig/Sheep", () => {
+    const getResponse = async () => {
+      const sbi = "106354662";
+      await setServerState(server, {
+        confirmedDetails: true,
+        customer: { attachedToMultipleBusinesses: true },
+        endemicsClaim: {
+          latestEndemicsApplication: {
+            sbi,
+            reference: "IAHW-TEST-NEW1",
+            redacted: false,
+            status: "AGREED",
+          },
+        },
+        organisation: { sbi, name: "PARTRIDGES", farmerName: "Janice Harrison" },
+      });
+      getClaimsByApplicationReference.mockResolvedValueOnce([]);
+      return server.inject({
+        url: "/livestock/manage-claims",
+        auth: { credentials: {}, strategy: "cookie" },
+      });
+    };
+
+    testBrowserPageTitle({
+      title: "Manage your livestock claims",
+      getResponse,
+    });
+
     test("new world, multiple businesses", async () => {
       const applicationReference = "IAHW-TEST-NEW1";
       const sbi = "106354662";
@@ -144,10 +172,6 @@ describe("GET /livestock/manage-claims", () => {
       });
 
       const $ = cheerio.load(payload);
-
-      expect($("title").text()).toContain(
-        "Manage your livestock claims - Get funding to improve animal health and welfare",
-      );
 
       expect(findByText($, "Important").length).toBe(0);
 


### PR DESCRIPTION
## Summary
Non-functional, test-only refactor of the Livestock narrow integration tests, now complete across the flavour.

It sweeps the bespoke inline browser-title and page-heading assertions onto the shared `testBrowserPageTitle` / `testPageHeading` helpers, and the logged-out 302-redirect assertions onto `testRedirectsToSignInWhenLoggedOut`, bringing Livestock into line with how Poultry already asserts these.

No production code changes; no asserted title, heading or redirect value changes.

## What Changed
- Apply screens (`you-can-claim-multiple`, `numbers`, `timings`, `declaration`) and the full set of claim screens now assert browser title and heading via the shared helpers.
- Title and heading are passed as separate values where they differ, making the distinction explicit rather than derived from one shared variable.
- Screens with a finite set of heading branches (review/follow-up, herd/flock, beef/dairy) adopt the helpers via multiple calls, one per branch - no helper changes needed.
- The Livestock dashboard (`vet-visits`) browser title now goes through the shared helper.
- Inline logged-out 302-redirect tests are replaced by the shared redirect helper across the touched files. Only pure redirect tests are swept; those that also assert a side-effect (e.g. no application created) or a 403 CSRF case are left bespoke.
- Where a test existed only to assert title/heading, it is folded into the helper calls; otherwise the "returns 200" test keeps its status, accessibility, content and back-link assertions with just the title/heading lines removed.
- Stabilised one file's session mock (`pi-hunt-all-animals`) so a persistent mock no longer leaks state between the helper calls and the "returns 200" cases.

Deliberately left bespoke (documented, not a helper gap): `species-numbers` (runtime numeric interpolation), `herd-others-on-sbi` (open species-group interpolation), `vet-visits-review-test-results` (heading is a legend with no `<h1>`, and is species-dependent), and the `sheep-test-results` heading (dynamic disease-name interpolation - its browser title is still migrated).

## Why
The apply/claim screens grew title and heading assertions in each file's own style, predating the shared helpers introduced alongside the Poultry title work. Consolidating onto the helpers reduces boilerplate, keeps the two flavours consistent, and expresses the title-vs-heading distinction explicitly. The full suite passes (1376 tests) with coverage unchanged.