### PR TITLE
chore: (ahwr-2003) consolidating date validation

### DIFF
--- a/app/lib/date-validations.js
+++ b/app/lib/date-validations.js
@@ -10,6 +10,7 @@ export const isValidDate = (year, month, day) => {
 };
 
 const DATE_PARTS = ["day", "month", "year"];
+const DATE_PARTS_COUNT = DATE_PARTS.length;
 
 const inputsInError = (flagged) =>
   Object.fromEntries(DATE_PARTS.map((part) => [part, flagged.includes(part)]));
@@ -32,4 +33,27 @@ export const validateDateParts = ({ day, month, year }) => {
   }
 
   return null;
+};
+
+/**
+ * Turns a {@link validateDateParts} descriptor into a user-facing message. The
+ * wording differs per screen, so the caller supplies the message text.
+ *
+ * @param {{ reason: string, missing: string[] }} partsError - Descriptor returned by {@link validateDateParts}.
+ * @param {object} messages - Screen-specific wording.
+ * @param {string} messages.enterDate - Shown when every date part is missing.
+ * @param {string} messages.subject - Leading phrase for a partially-missing date, e.g. "Date of review".
+ * @param {string} messages.realDate - Shown when the entered date is not a real date.
+ * @returns {string} The message to display.
+ */
+export const datePartsMessage = ({ reason, missing }, { enterDate, subject, realDate }) => {
+  if (reason === "incomplete") {
+    return missing.length === DATE_PARTS_COUNT
+      ? enterDate
+      : `${subject} must include a ${missing.join(" and a ")}`;
+  }
+  if (reason === "year") {
+    return "Year must include 4 numbers";
+  }
+  return realDate;
 };

--- a/app/lib/date-validations.js
+++ b/app/lib/date-validations.js
@@ -15,9 +15,17 @@ const DATE_PARTS_COUNT = DATE_PARTS.length;
 const inputsInError = (flagged) =>
   Object.fromEntries(DATE_PARTS.map((part) => [part, flagged.includes(part)]));
 
-// Validates the raw day/month/year strings of a GOV.UK date input as a single
-// unit. Returns null when the date is complete and real, otherwise a descriptor
-// the route maps to a message. Future/agreement-date rules live in the route.
+/**
+ * Validates the raw day/month/year strings of a GOV.UK date input as a single
+ * unit. Future/agreement-date rules live in the route.
+ *
+ * @param {{ day: string, month: string, year: string }} parts - The raw date input strings.
+ * @returns {{ reason: string, missing: string[], inputsInError: { day: boolean, month: boolean, year: boolean } } | null}
+ *   `null` when the date is complete and real, otherwise a descriptor the route
+ *   maps to a message via {@link datePartsMessage}. `reason` is one of
+ *   `"incomplete"` (parts missing), `"year"` (year out of range) or `"realDate"`
+ *   (not a real calendar date).
+ */
 export const validateDateParts = ({ day, month, year }) => {
   const missing = DATE_PARTS.filter((part) => ({ day, month, year })[part] === "");
   if (missing.length > 0) {

--- a/app/routes/livestock/claim/date-of-testing.js
+++ b/app/routes/livestock/claim/date-of-testing.js
@@ -7,7 +7,7 @@ import {
 } from "../../../session/index.js";
 import { getReviewType, getLivestockTypes } from "../../../lib/utils.js";
 
-import { validateDateParts } from "../../../lib/date-validations.js";
+import { validateDateParts, datePartsMessage } from "../../../lib/date-validations.js";
 import { getReviewWithinLast10Months } from "../../../lib/claim-helper.js";
 import {
   getReviewHerdId,
@@ -71,7 +71,6 @@ const getTheQuestionAndHintText = (typeOfReview, typeOfLivestock) => {
 
 const onAnotherDateInputId = "on-another-date";
 const dateOfSamplingText = "Date of sampling";
-const DATE_PARTS_COUNT = 3;
 
 const getHandler = {
   method: "GET",
@@ -206,20 +205,12 @@ const postPayloadSchema = Joi.object({
   [`${onAnotherDateInputId}-year`]: Joi.string().allow("").default(""),
 });
 
-const datePartsMessage = ({ reason, missing }) => {
-  if (reason === "incomplete") {
-    return missing.length === DATE_PARTS_COUNT
-      ? "Enter the date samples were taken"
-      : `${dateOfSamplingText} must include a ${missing.join(" and a ")}`;
-  }
-  if (reason === "year") {
-    return "Year must include 4 numbers";
-  }
-  return `${dateOfSamplingText} must be a real date`;
-};
-
 const buildDatePartsError = (request, partsError) => {
-  const message = datePartsMessage(partsError);
+  const message = datePartsMessage(partsError, {
+    enterDate: "Enter the date samples were taken",
+    subject: dateOfSamplingText,
+    realDate: `${dateOfSamplingText} must be a real date`,
+  });
   const { day, month, year } = partsError.inputsInError;
   return {
     errorSummary: [{ text: message, href: anchorTestingDate }],

--- a/app/routes/livestock/claim/date-of-visit.js
+++ b/app/routes/livestock/claim/date-of-visit.js
@@ -105,12 +105,11 @@ const buildErrorSummary = ({ errorMessage, href, inputsInError }) => {
 
 const visitDateDayAnchor = "#visit-date-day";
 
-const onAnotherDateInputId = "visit-date";
 const dateInputSchema = joi.object({
   crumb: joi.any(),
-  [`${onAnotherDateInputId}-day`]: joi.string().allow("").default(""),
-  [`${onAnotherDateInputId}-month`]: joi.string().allow("").default(""),
-  [`${onAnotherDateInputId}-year`]: joi.string().allow("").default(""),
+  "visit-date-day": joi.string().allow("").default(""),
+  "visit-date-month": joi.string().allow("").default(""),
+  "visit-date-year": joi.string().allow("").default(""),
 });
 
 const getInputsInError = (error) => {

--- a/app/routes/livestock/claim/date-of-visit.js
+++ b/app/routes/livestock/claim/date-of-visit.js
@@ -2,8 +2,6 @@ import joi from "joi";
 import {
   BEEF,
   DAIRY,
-  MAX_POSSIBLE_DAY,
-  MAX_POSSIBLE_MONTH,
   MULTIPLE_SPECIES_RELEASE_DATE,
   PI_HUNT_AND_DAIRY_FOLLOW_UP_RELEASE_DATE,
 } from "../../../constants/claim-constants.js";
@@ -11,7 +9,7 @@ import {
   getOldWorldClaimFromApplication,
   getAllClaimsForFirstHerd,
 } from "../../../lib/claim-helper.js";
-import { isValidDate } from "../../../lib/date-validations.js";
+import { validateDateParts } from "../../../lib/date-validations.js";
 import { getReviewType, getLivestockTypes } from "../../../lib/utils.js";
 import {
   getSessionData,
@@ -107,11 +105,26 @@ const buildErrorSummary = ({ errorMessage, href, inputsInError }) => {
 
 const visitDateDayAnchor = "#visit-date-day";
 
+const DATE_PARTS_COUNT = 3;
+
+const datePartsMessage = ({ reason, missing }, reviewOrFollowUpText) => {
+  if (reason === "incomplete") {
+    return missing.length === DATE_PARTS_COUNT
+      ? `Enter the date of ${reviewOrFollowUpText}`
+      : `Date of ${reviewOrFollowUpText} must include a ${missing.join(" and a ")}`;
+  }
+  if (reason === "year") {
+    return "Year must include 4 numbers";
+  }
+  return `The date of ${reviewOrFollowUpText} must be a real date`;
+};
+
+const onAnotherDateInputId = "visit-date";
 const dateInputSchema = joi.object({
   crumb: joi.any(),
-  "visit-date-day": joi.number().max(MAX_POSSIBLE_DAY),
-  "visit-date-month": joi.number().max(MAX_POSSIBLE_MONTH),
-  "visit-date-year": joi.number(),
+  [`${onAnotherDateInputId}-day`]: joi.string().allow("").default(""),
+  [`${onAnotherDateInputId}-month`]: joi.string().allow("").default(""),
+  [`${onAnotherDateInputId}-year`]: joi.string().allow("").default(""),
 });
 
 const getInputsInError = (error) => {
@@ -252,14 +265,15 @@ const postHandler = {
       const month = request.payload[visitDateHtml.labels.month];
       const year = request.payload[visitDateHtml.labels.year];
 
-      if (!isValidDate(Number(year), Number(month), Number(day))) {
+      const partsError = validateDateParts({ day, month, year });
+      if (partsError) {
         return respondWithDateError(
           request,
           h,
           buildErrorSummary({
-            errorMessage: `The date of ${reviewOrFollowUpText} must be a real date`,
+            errorMessage: datePartsMessage(partsError, reviewOrFollowUpText),
             href: visitDateDayAnchor,
-            inputsInError: { day: true, month: true, year: true },
+            inputsInError: partsError.inputsInError,
           }),
         );
       }

--- a/app/routes/livestock/claim/date-of-visit.js
+++ b/app/routes/livestock/claim/date-of-visit.js
@@ -9,7 +9,7 @@ import {
   getOldWorldClaimFromApplication,
   getAllClaimsForFirstHerd,
 } from "../../../lib/claim-helper.js";
-import { validateDateParts } from "../../../lib/date-validations.js";
+import { validateDateParts, datePartsMessage } from "../../../lib/date-validations.js";
 import { getReviewType, getLivestockTypes } from "../../../lib/utils.js";
 import {
   getSessionData,
@@ -104,20 +104,6 @@ const buildErrorSummary = ({ errorMessage, href, inputsInError }) => {
 };
 
 const visitDateDayAnchor = "#visit-date-day";
-
-const DATE_PARTS_COUNT = 3;
-
-const datePartsMessage = ({ reason, missing }, reviewOrFollowUpText) => {
-  if (reason === "incomplete") {
-    return missing.length === DATE_PARTS_COUNT
-      ? `Enter the date of ${reviewOrFollowUpText}`
-      : `Date of ${reviewOrFollowUpText} must include a ${missing.join(" and a ")}`;
-  }
-  if (reason === "year") {
-    return "Year must include 4 numbers";
-  }
-  return `The date of ${reviewOrFollowUpText} must be a real date`;
-};
 
 const onAnotherDateInputId = "visit-date";
 const dateInputSchema = joi.object({
@@ -271,7 +257,11 @@ const postHandler = {
           request,
           h,
           buildErrorSummary({
-            errorMessage: datePartsMessage(partsError, reviewOrFollowUpText),
+            errorMessage: datePartsMessage(partsError, {
+              enterDate: `Enter the date of ${reviewOrFollowUpText}`,
+              subject: `Date of ${reviewOrFollowUpText}`,
+              realDate: `The date of ${reviewOrFollowUpText} must be a real date`,
+            }),
             href: visitDateDayAnchor,
             inputsInError: partsError.inputsInError,
           }),

--- a/test/integration/narrow/routes/livestock/claim/date-of-testing.test.js
+++ b/test/integration/narrow/routes/livestock/claim/date-of-testing.test.js
@@ -487,11 +487,11 @@ describe("Date of testing", () => {
     describe("date checks", () => {
       test.each([
         {
-          scenario: "the date is incomplete",
-          day: "15",
-          month: "03",
-          year: "",
-          error: "Date of sampling must include a year",
+          scenario: "the entered date is of an incorrect format",
+          day: "second",
+          month: "february",
+          year: "2000",
+          error: "Date of sampling must be a real date",
         },
         {
           scenario: "the day cannot exist for the month entered",
@@ -501,11 +501,26 @@ describe("Date of testing", () => {
           error: "Date of sampling must be a real date",
         },
         {
-          scenario: "the day cannot be in the future",
+          scenario: "the date is before the agreement date",
+          day: "31",
+          month: "12",
+          year: "2021",
+          error:
+            "The date samples were taken must be the same as or after the date of your agreement",
+        },
+        {
+          scenario: "the date is in the future",
           day: `${tomorrow.getDate()}`,
           month: `${tomorrow.getMonth() + 1}`,
           year: `${tomorrow.getFullYear()}`,
           error: "The date samples were taken must be in the past",
+        },
+        {
+          scenario: "the date is incomplete",
+          day: "15",
+          month: "03",
+          year: "",
+          error: "Date of sampling must include a year",
         },
         {
           scenario: "the year is out of range",
@@ -513,14 +528,6 @@ describe("Date of testing", () => {
           month: "03",
           year: "10000",
           error: "Year must include 4 numbers",
-        },
-        {
-          scenario: "the sampling date is before the agreement",
-          day: "31",
-          month: "12",
-          year: "2021",
-          error:
-            "The date samples were taken must be the same as or after the date of your agreement",
         },
         {
           scenario: "day is missing",
@@ -564,34 +571,37 @@ describe("Date of testing", () => {
           year: "22",
           error: "Year must include 4 numbers",
         },
-      ])("redirects with an error when $scenario", async ({ day, month, year, error }) => {
-        getSessionData.mockImplementation(() => ({
-          dateOfVisit: "2024-01-01",
-          typeOfReview: "FOLLOW_UP",
-          typeOfLivestock: "beef",
-          latestEndemicsApplication,
-        }));
-        const res = await server.inject({
-          method: "POST",
-          url,
-          payload: {
-            crumb,
-            whenTestingWasCarriedOut: "onAnotherDate",
+      ])(
+        "redirects back to page with errors when $scenario",
+        async ({ day, month, year, error }) => {
+          getSessionData.mockImplementation(() => ({
             dateOfVisit: "2024-01-01",
-            dateOfAgreementAccepted: "2022-01-01",
-            "on-another-date-day": day,
-            "on-another-date-month": month,
-            "on-another-date-year": year,
-          },
-          auth,
-          headers: { cookie: `crumb=${crumb}` },
-        });
+            typeOfReview: "FOLLOW_UP",
+            typeOfLivestock: "beef",
+            latestEndemicsApplication,
+          }));
+          const res = await server.inject({
+            method: "POST",
+            url,
+            payload: {
+              crumb,
+              whenTestingWasCarriedOut: "onAnotherDate",
+              dateOfVisit: "2024-01-01",
+              dateOfAgreementAccepted: "2022-01-01",
+              "on-another-date-day": day,
+              "on-another-date-month": month,
+              "on-another-date-year": year,
+            },
+            auth,
+            headers: { cookie: `crumb=${crumb}` },
+          });
 
-        expect(await axe(res.payload)).toHaveNoViolations();
-        const $ = cheerio.load(res.payload);
-        expect(res.statusCode).toBe(HttpStatus.BAD_REQUEST);
-        expect($(".govuk-error-summary__list a").text()).toContain(error);
-      });
+          expect(await axe(res.payload)).toHaveNoViolations();
+          const $ = cheerio.load(res.payload);
+          expect(res.statusCode).toBe(HttpStatus.BAD_REQUEST);
+          expect($(".govuk-error-summary__list a").text()).toContain(error);
+        },
+      );
 
       test("redirects with an error if the sampling date is before the agreement date", async () => {
         getSessionData.mockImplementation(() => ({

--- a/test/integration/narrow/routes/livestock/claim/date-of-visit.test.js
+++ b/test/integration/narrow/routes/livestock/claim/date-of-visit.test.js
@@ -67,6 +67,10 @@ const organisation = {
 const auth = { credentials: {}, strategy: "cookie" };
 const url = "/livestock/date-of-visit";
 
+const today = new Date();
+const tomorrow = new Date(today);
+tomorrow.setDate(today.getDate() + 1);
+
 describe("GET /livestock/date-of-visit handler", () => {
   let server;
 
@@ -321,35 +325,99 @@ describe("POST /livestock/date-of-visit handler", () => {
         day: "second",
         month: "february",
         year: "2000",
-        error: "Enter the date of review",
+        error: "The date of review must be a real date",
         kind: "dateEntered: 2000-february-second, dateOfAgreement: 2025-01-01",
       },
       {
-        scenario: "the entered date is of a correct format, but the date isn't real",
+        scenario: "the day cannot exist for the month entered",
         day: "31",
-        month: "2",
-        year: "2025",
+        month: "02",
+        year: "2023",
         error: "The date of review must be a real date",
-        kind: "dateEntered: 2025-2-31, dateOfAgreement: 2025-01-01",
+        kind: "dateEntered: 2023-02-31, dateOfAgreement: 2025-01-01",
       },
       {
-        scenario: "the entered date is before the agreement date",
-        day: "1",
+        scenario: "the date is before the agreement date",
+        day: "31",
         month: "12",
-        year: "2024",
+        year: "2021",
         error: "The date of review must be the same as or after the date of your agreement",
-        kind: "dateEntered: 2024-12-1, dateOfAgreement: 2025-01-01",
+        kind: "dateEntered: 2021-12-31, dateOfAgreement: 2025-01-01",
       },
       {
-        scenario: "the entered date is in the future",
-        day: "2",
-        month: "2",
-        year: "2040",
+        scenario: "the date is in the future",
+        day: `${tomorrow.getDate()}`,
+        month: `${tomorrow.getMonth() + 1}`,
+        year: `${tomorrow.getFullYear()}`,
         error: "The date of review must be today or in the past",
-        kind: "dateEntered: 2040-2-2, dateOfAgreement: 2025-01-01",
+        kind: `dateEntered: ${tomorrow.getFullYear()}-${tomorrow.getMonth() + 1}-${tomorrow.getDate()}, dateOfAgreement: 2025-01-01`,
+      },
+      {
+        scenario: "the date is incomplete",
+        day: "15",
+        month: "03",
+        year: "",
+        error: "Date of review must include a year",
+        kind: "dateEntered: -03-15, dateOfAgreement: 2025-01-01",
+      },
+      {
+        scenario: "the year is out of range",
+        day: "15",
+        month: "03",
+        year: "10000",
+        error: "Year must include 4 numbers",
+        kind: "dateEntered: 10000-03-15, dateOfAgreement: 2025-01-01",
+      },
+      {
+        scenario: "day is missing",
+        day: "",
+        month: "03",
+        year: "2023",
+        error: "Date of review must include a day",
+        kind: "dateEntered: 2023-03-, dateOfAgreement: 2025-01-01",
+      },
+      {
+        scenario: "month is missing",
+        day: "15",
+        month: "",
+        year: "2023",
+        error: "Date of review must include a month",
+        kind: "dateEntered: 2023--15, dateOfAgreement: 2025-01-01",
+      },
+      {
+        scenario: "day and month are missing",
+        day: "",
+        month: "",
+        year: "2023",
+        error: "Date of review must include a day and a month",
+        kind: "dateEntered: 2023--, dateOfAgreement: 2025-01-01",
+      },
+      {
+        scenario: "day and year are missing",
+        day: "",
+        month: "03",
+        year: "",
+        error: "Date of review must include a day and a year",
+        kind: "dateEntered: -03-, dateOfAgreement: 2025-01-01",
+      },
+      {
+        scenario: "month and year are missing",
+        day: "15",
+        month: "",
+        year: "",
+        error: "Date of review must include a month and a year",
+        kind: "dateEntered: --15, dateOfAgreement: 2025-01-01",
+      },
+      {
+        scenario: "year has only 2 digits",
+        day: "15",
+        month: "03",
+        year: "22",
+        error: "Year must include 4 numbers",
+        kind: "dateEntered: 22-03-15, dateOfAgreement: 2025-01-01",
       },
     ])(
-      "redirect back to page with errors if $scenario",
+      "redirects back to page with errors when $scenario",
       async ({ day, month, year, error, kind }) => {
         when(getSessionData)
           .calledWith(expect.anything(), sessionEntryKeys.endemicsClaim)


### PR DESCRIPTION
This consolidates the way that the date validation works, being the same on date-of-visit and date-of-testing for livestocks. The errors thrown are consistent on both sides. Common code has been extracted. And the tests for invalid date are the same in both sides.