### PR TITLE
fix(security): (AHWR-2091) remove obsolete Permissions-Policy header #patch

### DIFF
--- a/app/plugins/header.js
+++ b/app/plugins/header.js
@@ -71,7 +71,6 @@ export const headerPlugin = {
       { key: "Strict-Transport-Security", value: "max-age=31536000;" },
       { key: "Cache-Control", value: "no-store" },
       { key: "Referrer-Policy", value: "no-referrer" },
-      { key: "Permissions-Policy", value: "Interest-Cohort=()" },
     ],
   },
 };

--- a/test/unit/app/plugins/headers.test.js
+++ b/test/unit/app/plugins/headers.test.js
@@ -44,6 +44,12 @@ test("omits the deprecated X-XSS-Protection header", async () => {
   expect(headers["x-xss-protection"]).toBeUndefined();
 });
 
+test("omits the obsolete Permissions-Policy header", async () => {
+  const headers = await getHeaders();
+
+  expect(headers["permissions-policy"]).toBeUndefined();
+});
+
 test("retains X-Frame-Options deny alongside frame-ancestors", async () => {
   const headers = await getHeaders();
 


### PR DESCRIPTION
## Summary
Removes the broken `Permissions-Policy: Interest-Cohort=()` response header.

Its capitalised key is an invalid HTTP structured-field dictionary key, so browsers reject the entire header and log a `Parse of permissions policy failed` error in the console on every page, in all environments, regardless of the CSP enforce flag. The interest-cohort (FLoC) directive is also obsolete and no longer exists in any browser.

## What Changed
- Removed the `Permissions-Policy` entry from the header plugin's header list.
- Added a regression test asserting the header is absent from responses, mirroring the existing deprecated-header (X-XSS-Protection) test.

## Why
The header was doing nothing useful: the invalid value meant browsers dropped it entirely, so there has effectively been no `Permissions-Policy` on the live service. The directive it carried targeted FLoC, which no longer exists. Removing it silences the per-page console error and leaves no malformed header behind.

This is a pre-existing defect, separate from the earlier CSP hardening work, and does not weaken the security posture: the service does not use the browser features a Permissions-Policy would restrict, and it is already unframeable via `frame-ancestors 'none'` and `X-Frame-Options: deny`.