### PR TITLE
fix(claims): (AHWR-2127) guard missing relevantReviewForEndemics in pi-hunt #patch

### DIFF
--- a/app/routes/livestock/claim/pi-hunt.js
+++ b/app/routes/livestock/claim/pi-hunt.js
@@ -119,7 +119,7 @@ const postHandler = {
 };
 
 const isFollowUpOfNewWorldReview = (relevantReviewForEndemics) => {
-  return relevantReviewForEndemics.type === claimType.review;
+  return relevantReviewForEndemics?.type === claimType.review;
 };
 
 export const piHuntHandlers = [getHandler, postHandler];

--- a/app/routes/livestock/claim/vet-rcvs.js
+++ b/app/routes/livestock/claim/vet-rcvs.js
@@ -27,7 +27,7 @@ const nextPageURL = (request) => {
   );
 
   if (isEndemicsFollowUp) {
-    if (relevantReviewForEndemics.type === claimType.vetVisits && isPigs) {
+    if (relevantReviewForEndemics?.type === claimType.vetVisits && isPigs) {
       return livestockClaimRoutes.vetVisitsReviewTestResults;
     }
     if (isSheep) {

--- a/test/integration/narrow/routes/livestock/claim/pi-hunt.test.js
+++ b/test/integration/narrow/routes/livestock/claim/pi-hunt.test.js
@@ -177,6 +177,27 @@ describe("PI Hunt tests when Optional PI Hunt is OFF", () => {
       expect(clearPiHuntSessionOnChange).not.toHaveBeenCalled();
     });
 
+    test("Continue to ineligible page if user select no and does not clear PI Hunt data when relevantReviewForEndemics is missing", async () => {
+      const options = {
+        method: "POST",
+        payload: { crumb, piHunt: "no" },
+        auth,
+        url,
+        headers: { cookie: `crumb=${crumb}` },
+      };
+      getSessionData.mockImplementation(() => {
+        return { typeOfLivestock: "beef" };
+      });
+
+      const res = await server.inject(options);
+
+      expect(res.statusCode).toBe(400);
+      const $ = cheerio.load(res.payload);
+      expect($("h1").text()).toMatch("You cannot continue with your claim");
+      expect(sendInvalidDataEvent).toHaveBeenCalled();
+      expect(clearPiHuntSessionOnChange).not.toHaveBeenCalled();
+    });
+
     test("shows error when payload is invalid", async () => {
       getSessionData.mockImplementation(() => {
         return { typeOfLivestock: "beef", reviewTestResults: "positive" };

--- a/test/integration/narrow/routes/livestock/claim/vet-rcvs.test.js
+++ b/test/integration/narrow/routes/livestock/claim/vet-rcvs.test.js
@@ -229,6 +229,18 @@ describe("Vet rcvs test when Optional PI Hunt is OFF", () => {
       },
       {
         typeOfLivestock: "beef",
+        typeOfReview: "FOLLOW_UP",
+        relevantReviewForEndemics: undefined,
+        nextPageURL: "/livestock/test-urn",
+      },
+      {
+        typeOfLivestock: "pigs",
+        typeOfReview: "FOLLOW_UP",
+        relevantReviewForEndemics: undefined,
+        nextPageURL: "/livestock/vaccination",
+      },
+      {
+        typeOfLivestock: "beef",
         typeOfReview: "REVIEW",
         relevantReviewForEndemics: undefined,
         nextPageURL: "/livestock/test-urn",


### PR DESCRIPTION
## Summary

Farmers making a livestock (BVD cattle) claim hit a 500 error and the generic "Sorry there is a problem with the service" page when they answered "no" to the PI hunt question. This fixes the crash so the journey continues to the correct ineligible page, and hardens a second route with the same latent fault.

## What Changed

- Guarded a session value that was being dereferenced without a null check in the PI hunt POST handler
- Applied the same guard in the vet RCVS next-page routing, where the identical unguarded dereference was reachable on a follow-up claim
- Added integration tests for both handlers covering the case where that session value is absent

## Why

Both handlers read a property of the relevant review from session state, assuming it was always present. When it was not, the request threw an unhandled TypeError and returned a 500.

In the PI hunt handler this was live: production logs confirmed it as the sole source of 500s in the claim journey, reported via RPA ops after a customer could not submit. The only path that hit it was answering "no" to the PI hunt question, which is why other journeys were unaffected.

The vet RCVS handler carried the same unguarded dereference. It was not yet failing in production because its path is reached only by a follow-up claim, but a test-first check confirmed it would throw under that condition, so it is fixed here rather than left as a known trap.

In both cases the guard returns the correct result when the value is missing (no relevant review means it is not the relevant claim type), so the journeys now route as intended rather than crashing.

The existing tests only covered the value being present, which is how both gaps went unnoticed. The dereferences have been latent since the claim routes were first added, so these are long-standing edge cases rather than recent regressions.