### PR TITLE
fix(security): (AHWR-1997) stop dev CSP override crashing on error responses #patch

### DIFF
--- a/app/plugins/dev-redirect.js
+++ b/app/plugins/dev-redirect.js
@@ -4,12 +4,16 @@ export const devRedirectPlugin = {
     register: (server, _) => {
       server.ext("onPreResponse", (request, h) => {
         if (request.path === "/check-details") {
-          const response = h.request.response;
-          response.headers["content-security-policy"] = response.headers[
-            "content-security-policy"
-          ].replace("form-action 'self'", "form-action *");
+          const response = request.response;
+          const headers = response.isBoom ? response.output.headers : response.headers;
+          const csp = headers["content-security-policy"];
+
+          if (csp) {
+            headers["content-security-policy"] = csp.replace("form-action 'self'", "form-action *");
+          }
         }
-        return h.request.response;
+
+        return h.continue;
       });
     },
   },

--- a/test/unit/app/plugins/dev-redirect.test.js
+++ b/test/unit/app/plugins/dev-redirect.test.js
@@ -1,0 +1,92 @@
+import { devRedirectPlugin } from "../../../../app/plugins/dev-redirect.js";
+
+const CSP_HEADER = "content-security-policy";
+
+describe("dev-redirect plugin", () => {
+  let onPreResponseHandler;
+  const mockH = { continue: Symbol("continue") };
+
+  beforeAll(() => {
+    const mockServer = {
+      ext: (event, handler) => {
+        if (event === "onPreResponse") {
+          onPreResponseHandler = handler;
+        }
+      },
+    };
+    devRedirectPlugin.plugin.register(mockServer);
+  });
+
+  test("relaxes form-action on the /check-details view response", () => {
+    const request = {
+      path: "/check-details",
+      response: {
+        isBoom: false,
+        headers: {
+          [CSP_HEADER]: "default-src 'self';form-action 'self';frame-ancestors 'none'",
+        },
+      },
+    };
+
+    const result = onPreResponseHandler(request, mockH);
+
+    expect(result).toBe(mockH.continue);
+    expect(request.response.headers[CSP_HEADER]).toBe(
+      "default-src 'self';form-action *;frame-ancestors 'none'",
+    );
+  });
+
+  test("relaxes form-action on a Boom response via output.headers", () => {
+    const request = {
+      path: "/check-details",
+      response: {
+        isBoom: true,
+        output: {
+          headers: { [CSP_HEADER]: "form-action 'self'" },
+        },
+      },
+    };
+
+    onPreResponseHandler(request, mockH);
+
+    expect(request.response.output.headers[CSP_HEADER]).toBe("form-action *");
+  });
+
+  test("does nothing when a view response has no CSP header", () => {
+    const request = {
+      path: "/check-details",
+      response: { isBoom: false, headers: {} },
+    };
+
+    const result = onPreResponseHandler(request, mockH);
+
+    expect(result).toBe(mockH.continue);
+    expect(request.response.headers[CSP_HEADER]).toBeUndefined();
+  });
+
+  test("does nothing when a Boom response has no CSP header", () => {
+    const request = {
+      path: "/check-details",
+      response: { isBoom: true, output: { headers: {} } },
+    };
+
+    const result = onPreResponseHandler(request, mockH);
+
+    expect(result).toBe(mockH.continue);
+    expect(request.response.output.headers[CSP_HEADER]).toBeUndefined();
+  });
+
+  test("ignores paths other than /check-details", () => {
+    const request = {
+      path: "/some-other-page",
+      response: {
+        isBoom: false,
+        headers: { [CSP_HEADER]: "form-action 'self'" },
+      },
+    };
+
+    onPreResponseHandler(request, mockH);
+
+    expect(request.response.headers[CSP_HEADER]).toBe("form-action 'self'");
+  });
+});


### PR DESCRIPTION
## Summary
The move to the Blankie CSP plugin changed where the `Content-Security-Policy` header is attached on error responses, which broke the dev-login-only CSP override on the check-details page.

On any error response from that page the override crashed with a "cannot read properties of undefined" error, taking down the local dev login journey. This fixes the override to read the header from the location the CSP plugin actually uses for error responses, and to no-op safely when no policy header is present. Dev-login only; no production or consumer-facing behaviour changes.

## What Changed
- The dev CSP override on the check-details page now reads the policy header from the correct store for both normal and error responses, and skips cleanly when no header is present rather than throwing.
- Added a unit test for the override covering the normal, error, and missing-header paths (it previously had none, which is why the regression slipped through).

## Why
Blankie attaches the CSP header to a different place on error responses than on normal ones. The dev override still assumed the single location the old hand-rolled header plugin always used, so it threw as soon as the check-details page returned an error. This restores the override across all response types while keeping the change confined to the dev-login path.