### PR TITLE
fix(auth): (AHWR-1997) return authorization code url as a string #patch

### DIFF
--- a/app/auth/auth-code-grant/request-authorization-code-url.js
+++ b/app/auth/auth-code-grant/request-authorization-code-url.js
@@ -27,5 +27,5 @@ export const requestAuthorizationCodeUrl = async (request, ssoOrgId) => {
   url.searchParams.append("code_challenge", codeChallenge);
   url.searchParams.append("code_challenge_method", "S256");
 
-  return url;
+  return url.toString();
 };

--- a/test/integration/narrow/routes/sign-in.test.js
+++ b/test/integration/narrow/routes/sign-in.test.js
@@ -27,7 +27,7 @@ describe("/sign-in", () => {
     });
 
     expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY);
-    expect(res.headers.location.href).toMatch(DEFRA_ID_BASE_URL);
+    expect(res.headers.location).toMatch(DEFRA_ID_BASE_URL);
     expect(clearAllOfSession).toHaveBeenCalled();
     expect(metricsCounter).toHaveBeenCalledWith("sign_in");
   });
@@ -40,8 +40,8 @@ describe("/sign-in", () => {
     });
 
     expect(res.statusCode).toBe(StatusCodes.MOVED_TEMPORARILY);
-    expect(res.headers.location.href).toMatch(DEFRA_ID_BASE_URL);
-    expect(res.headers.location.href).toContain(ssoOrgId);
+    expect(res.headers.location).toMatch(DEFRA_ID_BASE_URL);
+    expect(res.headers.location).toContain(ssoOrgId);
     expect(clearAllOfSession).toHaveBeenCalled();
     expect(metricsCounter).toHaveBeenCalledWith("sign_in");
   });

--- a/test/unit/app/auth/authorize.test.js
+++ b/test/unit/app/auth/authorize.test.js
@@ -16,6 +16,11 @@ describe("Generate authentication url test", () => {
     expect(params.get("code_challenge")).not.toBeNull();
   });
 
+  test("requestAuthorizationCodeUrl returns a string so it is safe to use in a view context", async () => {
+    const result = await requestAuthorizationCodeUrl();
+    expect(typeof result).toBe("string");
+  });
+
   test("when invalid state occurs", async () => {
     verifyState.mockReturnValueOnce(false);
     const request = { yar: { id: "33" }, logger: { error: jest.fn() } };


### PR DESCRIPTION
## Summary
Two regressions surfaced after the `Content-Security-Policy` was migrated to the Blankie plugin, both stemming from Blankie processing responses differently from the previous hand-rolled header. Together they broke the authenticated journeys (the sign-in confirmation page failing to render) and the local dev-login flow. This PR fixes both. There is no production behaviour change beyond restoring correct rendering.

## What Changed
- The Defra ID sign-in URL helper now returns a string instead of a URL object. Blankie deep-clones the view context to inject its per-request nonce, and a URL object does not survive that clone, which crashed rendering on every page that embeds the sign-in link (check-details, select-funding, manage-claims, the login-failed page and others).
- The dev-login-only CSP override on the check-details page now reads the policy header from the correct place for error responses and no-ops safely when no header is present, instead of throwing.
- Tests: a unit test locking the string return (the root-cause guard), dev-override tests covering the normal, error and missing-header paths, and redirect-location assertions updated to match the string return.

## Why
The old hand-rolled header plugin did neither of the things Blankie now does: it did not clone the view context (so a URL object placed there rendered fine), and it always attached the policy to the same location. Both differences only manifest in the deployed runtime, which is why they passed the Jest suite and were caught instead by the browser-based ui-tests and production logs. These changes remove the URL-object hazard at its source and make the dev override resilient to Blankie's response handling.