### PR TITLE
fix(security): (AHWR-2148) allow the Defra ID origin as a form-action target #patch

### DIFF
--- a/app/plugins/content-security-policy.js
+++ b/app/plugins/content-security-policy.js
@@ -1,7 +1,12 @@
 import Blankie from "blankie";
+import { authConfig } from "../config/auth.js";
 
 const GOOGLE_ANALYTICS = "*.google-analytics.com";
 const GOOGLE_TAG_MANAGER = "*.googletagmanager.com";
+
+// Session expiry redirects form submissions on to Defra ID, and form-action applies to the whole redirect chain
+export const buildFormActionSources = ({ tenantName, hostname }) =>
+  tenantName ? ["self", new URL(hostname).origin] : ["self"];
 
 export const contentSecurityPolicyPlugin = {
   plugin: Blankie,
@@ -9,7 +14,7 @@ export const contentSecurityPolicyPlugin = {
     defaultSrc: ["self"],
     objectSrc: ["none"],
     scriptSrc: ["self", "www.google-analytics.com", GOOGLE_TAG_MANAGER],
-    formAction: ["self"],
+    formAction: buildFormActionSources(authConfig.defraId),
     baseUri: ["self"],
     connectSrc: ["self", GOOGLE_ANALYTICS, "*.analytics.google.com", GOOGLE_TAG_MANAGER],
     styleSrc: ["self", "tagmanager.google.com", "*.googleapis.com"],

--- a/test/setup.js
+++ b/test/setup.js
@@ -17,5 +17,6 @@ process.env.RPA_GET_PERSON_SUMMARY_URL = "http://rpa.com";
 process.env.RPA_GET_ORGANISATION_PERMISSIONS_URL = "/api/organisation/organisationId/permissions";
 process.env.RPA_GET_ORGANISATION_URL = "/api/organisation/organisationId";
 process.env.RPA_GET_CPH_NUMBERS_URL = "/api/organisation/organisationId/cph";
+process.env.DEFRA_ID_TENANT = "dcidmtest";
 
 config();

--- a/test/unit/app/plugins/csp-form-action.test.js
+++ b/test/unit/app/plugins/csp-form-action.test.js
@@ -1,0 +1,22 @@
+import { buildFormActionSources } from "../../../../app/plugins/content-security-policy.js";
+
+describe("form-action sources", () => {
+  const defraId = {
+    tenantName: "dcidm",
+    hostname: "https://dcidm.b2clogin.com/dcidm.onmicrosoft.com",
+  };
+
+  test("allows the Defra ID origin for the configured tenant", () => {
+    expect(buildFormActionSources(defraId)).toEqual(["self", "https://dcidm.b2clogin.com"]);
+  });
+
+  test("allows the Defra ID origin without the tenant path segment", () => {
+    expect(buildFormActionSources(defraId)).not.toContainEqual(
+      expect.stringContaining("onmicrosoft.com"),
+    );
+  });
+
+  test("allows self only when no Defra ID tenant is configured", () => {
+    expect(buildFormActionSources({ ...defraId, tenantName: undefined })).toEqual(["self"]);
+  });
+});

--- a/test/unit/app/plugins/csp-header.test.js
+++ b/test/unit/app/plugins/csp-header.test.js
@@ -44,8 +44,14 @@ describe("content security policy directives", () => {
     expect(directives["frame-ancestors"]).toEqual(["'none'"]);
   });
 
-  test("restricts form-action to self", () => {
-    expect(directives["form-action"]).toEqual(["'self'"]);
+  test("allows self and the Defra ID origin in form-action", () => {
+    expect(new Set(directives["form-action"])).toEqual(
+      new Set(["'self'", "https://dcidmtest.b2clogin.com"]),
+    );
+  });
+
+  test("does not allow arbitrary hosts as form targets", () => {
+    expect(directives["form-action"]).not.toContain("*");
   });
 
   test("restricts base-uri to self", () => {


### PR DESCRIPTION
## Summary

Fixes a bug where submitting a form after the session had expired failed silently.

The page appeared to do nothing, the user got no feedback, and their answers were lost. The Content Security Policy was blocking the redirect to Defra ID, because `form-action 'self'` is enforced against the entire redirect chain that follows a form submission, and the Defra ID host is not same-origin.

The policy now allows the environment's Defra ID origin.

## What Changed

- `form-action` allows the Defra ID origin alongside `'self'`, derived per environment from the configured tenant so it follows dev, test, perf-test and prod automatically
- No origin is added when no tenant is configured, so environments without Defra ID config do not end up with a placeholder host in their policy
- Unit tests covering the derivation and the no-tenant guard, plus an updated assertion on the rendered policy header
- Test setup seeds a Defra ID tenant so the rendered header is asserted against a realistic value

## Why

This affects every form submission in the service, not just the screen it was reported on. Any POST made after the session expired was silently blackholed, leaving the user with no feedback and no way forward short of manually navigating to sign in.

The defect is long standing (`form-action 'self'` predates the recent move to the blankie plugin) but was only reachable once the session timeout was shortened. That is why it surfaced during exploratory testing of the timeout work, which was reverted as a result and is unblocked by this change.