### PR TITLE
ci: (AHWR-2118) allow build, perf and revert types in pr title lint #patch

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -13,5 +13,5 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           echo "PR title: $PR_TITLE"
-          echo "$PR_TITLE" | grep -Pq '^(feat|fix|chore|docs|style|refactor|test|ci)(\(.+\))?: .+' \
+          echo "$PR_TITLE" | grep -Pq '^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\(.+\))?: .+' \
             || (echo "❌ PR title must follow Conventional Commits" && exit 1)


### PR DESCRIPTION
## Summary

The pull request title check rejects valid Conventional Commits types.

Its allowed list has eight entries where the specification defines eleven, and one of the missing three is `build`, which is exactly what Dependabot uses for dependency bumps. Every Dependabot pull request therefore fails the check. This widens the list to match the specification.

## What Changed

- Added `build`, `perf` and `revert` to the accepted type list in the pull request title workflow, and sorted the list alphabetically. It now matches the `type-enum` used by `@commitlint/config-conventional`.

## Why

Dependabot titles its dependency pull requests `build(deps):` and `build(deps-dev):`. That is the correct Conventional Commits type for the job, defined as changes affecting the build system or external dependencies. The check was rejecting them purely because its list was incomplete.