### PR TITLE
fix(auth): (AHWR-2118) migrate @hapi/cookie to v12 validate/isValid #patch

### DIFF
--- a/app/plugins/auth-plugin.js
+++ b/app/plugins/auth-plugin.js
@@ -38,7 +38,7 @@ export const authPlugin = {
         redirectTo: (_request) => {
           return "/sign-in";
         },
-        validateFunc: async (request) => {
+        validate: async (request) => {
           request.app[AUTH_COOKIE_VALIDATED] = true;
           const sessionWasSet = Boolean(getSessionData(request, sessionEntryKeys.organisation));
 
@@ -49,7 +49,7 @@ export const authPlugin = {
             );
           }
 
-          return { valid: sessionWasSet };
+          return { isValid: sessionWasSet };
         },
       });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@hapi/boom": "9.1.4",
         "@hapi/catbox-memory": "5.0.1",
         "@hapi/catbox-redis": "7.0.2",
-        "@hapi/cookie": "11.0.2",
+        "@hapi/cookie": "12.0.1",
         "@hapi/crumb": "8.0.1",
         "@hapi/hapi": "21.4.9",
         "@hapi/inert": "7.1.2",
@@ -2333,15 +2333,50 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@hapi/cookie": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/@hapi/cookie/-/cookie-11.0.2.tgz",
-      "integrity": "sha512-LRpSuHC53urzml83c5eUHSPPt7YtK1CaaPZU9KmnhZlacVVojrWJzOUIcwOADDvCZjDxowCO3zPMaOqzEm9kgg==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/cookie/-/cookie-12.0.1.tgz",
+      "integrity": "sha512-TpykARUIgTBvgbsgtYe5CrM/7XBGms2/22JD3N6dzct6bG1vcOC6pH1JWIos1O5zvQnyDSJ2pnaFk+DToHkAng==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@hapi/boom": "9.x.x",
-        "@hapi/bounce": "2.x.x",
-        "@hapi/hoek": "9.x.x",
-        "@hapi/validate": "1.x.x"
+        "@hapi/boom": "^10.0.1",
+        "@hapi/bounce": "^3.0.1",
+        "@hapi/hoek": "^11.0.2",
+        "@hapi/validate": "^2.0.1"
+      }
+    },
+    "node_modules/@hapi/cookie/node_modules/@hapi/boom": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-10.0.1.tgz",
+      "integrity": "sha512-ERcCZaEjdH3OgSJlyjVk8pHIFeus91CjKP3v+MpgBNp5IvGzP2l/bRiD78nqYcKPaZdbKkK5vDBVPd2ohHBlsA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2"
+      }
+    },
+    "node_modules/@hapi/cookie/node_modules/@hapi/bounce": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/bounce/-/bounce-3.0.2.tgz",
+      "integrity": "sha512-d0XmlTi3H9HFDHhQLjg4F4auL1EY3Wqj7j7/hGDhFFe6xAbnm3qiGrXeT93zZnPH8gH+SKAFYiRzu26xkXcH3g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/boom": "^10.0.1",
+        "@hapi/hoek": "^11.0.2"
+      }
+    },
+    "node_modules/@hapi/cookie/node_modules/@hapi/hoek": {
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.7.tgz",
+      "integrity": "sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/cookie/node_modules/@hapi/validate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-2.0.1.tgz",
+      "integrity": "sha512-NZmXRnrSLK8MQ9y/CMqE9WSspgB9xA41/LlYR0k967aSZebWr4yNrpxIbov12ICwKy4APSlWXZga9jN5p6puPA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2",
+        "@hapi/topo": "^6.0.1"
       }
     },
     "node_modules/@hapi/crumb": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@hapi/boom": "9.1.4",
     "@hapi/catbox-memory": "5.0.1",
     "@hapi/catbox-redis": "7.0.2",
-    "@hapi/cookie": "11.0.2",
+    "@hapi/cookie": "12.0.1",
     "@hapi/crumb": "8.0.1",
     "@hapi/hapi": "21.4.9",
     "@hapi/inert": "7.1.2",

--- a/test/unit/app/plugins/cookies.test.js
+++ b/test/unit/app/plugins/cookies.test.js
@@ -43,9 +43,7 @@ describe("Cookie plugin", () => {
           method: "GET",
           path: "/",
           handler: (req, h) => {
-            return h.view("index", {
-              /* context */
-            });
+            return h.view("index", {/* context */});
           },
         },
         {
@@ -68,9 +66,7 @@ describe("Cookie plugin", () => {
 
     test("should apply cookie policy for non-error, view responses", async () => {
       const getCurrentPolicy = require("../../../../app/cookies.js").getCurrentPolicy;
-      getCurrentPolicy.mockReturnValue({
-        /* Your mock policy data */
-      });
+      getCurrentPolicy.mockReturnValue({/* Your mock policy data */});
       request = {
         method: "get",
         url: "/blah",


### PR DESCRIPTION
## Summary

Adapts the cookie auth strategy to @hapi/cookie v12, which renames the session validation option and changes its expected return shape. This unblocks the Dependabot bump of @hapi/cookie from 11.0.2 to 12.0.1, which cannot merge on its own because v12 rejects the old option name.

## What Changed

- Renamed the cookie strategy's `validateFunc` option to `validate`.
- Changed the validator's return from `{ valid }` to `{ isValid }` to match v12's contract.
- Bumped `@hapi/cookie` from 11.0.2 to 12.0.1.

## Why

@hapi/cookie v12 removed `validateFunc` (now `validate`) and renamed the return property `valid` to `isValid`. The old names throw a validation error at strategy registration, so the dependency bump and this code change must land together. Auth behaviour is unchanged; the existing auth plugin test suite covers both the valid-session and missing-organisation paths. Supersedes the standalone Dependabot bump PR, which should be closed.