### PR TITLE
refactor: (AHWR-2118) remove vestigial jquery dependency #patch

### DIFF
--- a/app/frontend/src/entry.js
+++ b/app/frontend/src/entry.js
@@ -9,9 +9,6 @@ import "./css/govspeak.scss";
 import "./css/organisation-logo.scss";
 import "./js/cookies.js";
 import "./js/handleDuplicateFormSubmissions.js";
-import jquery from "jquery";
 
 initAll();
 initMoj();
-
-window.$ = jquery;

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
         "http-status-codes": "2.3.0",
         "ioredis": "5.6.1",
         "joi": "18.2.5",
-        "jquery": "3.7.1",
         "jsonwebtoken": "9.0.3",
         "jwk-to-pem": "2.0.7",
         "moment": "2.30.1",
@@ -12546,12 +12545,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/jquery": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
-      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
-      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "http-status-codes": "2.3.0",
     "ioredis": "5.6.1",
     "joi": "18.2.5",
-    "jquery": "3.7.1",
     "jsonwebtoken": "9.0.3",
     "jwk-to-pem": "2.0.7",
     "moment": "2.30.1",


### PR DESCRIPTION
## Summary

Removes jQuery as a vestigial dependency: the application's own JavaScript is entirely vanilla, and the current @ministryofjustice/frontend (v9) is jQuery-free, so the `import jquery` and `window.$ = jquery` global in the frontend entry point served nothing. The `window.$` assignment even ran after `initMoj()`, so MOJ Frontend could not have relied on it.

Dependabot raised a jQuery 3 -> 4 major (#332); rather than upgrade a dependency nothing uses, this removes it. The production JS bundle roughly halves as a result (down to ~86 KiB).

## What Changed

- Removed the `jquery` import and the `window.$ = jquery` global assignment from the frontend entry point.
- Removed `jquery` from `package.json` and the lockfile.

## Why

The `window.$` global existed only to satisfy older MOJ Frontend components; MOJ Frontend has since dropped jQuery, and nothing in the app code or templates references `$`, `window.$`, or `jQuery`. So the dependency was dead weight - a ~279 KiB source library contributing nothing but bundle size. Removing it resolves the jQuery 4 Dependabot PR with no upgrade needed, halves the JS bundle, and is a straightforward simplification with no behaviour change. Webpack builds clean and the full test suite passes; the cookie banner and MOJ sortable table were confirmed unaffected as they rely on govuk-frontend and MOJ Frontend, not jQuery.