### PR TITLE
chore(deps): (AHWR-2118) ignore jsdom and global-jsdom majors pending coordinated migration #patch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -57,6 +57,13 @@ updates:
       - dependency-name: global-agent
         update-types:
           - version-update:semver-major
+      # jsdom and global-jsdom pinned to major 26: the pair is version-coupled (global-jsdom 26 targets jsdom 26) and global-jsdom carries a patch-package patch tied to 26, so a major bump needs a coordinated migration plus patch regeneration (deferred)
+      - dependency-name: jsdom
+        update-types:
+          - version-update:semver-major
+      - dependency-name: global-jsdom
+        update-types:
+          - version-update:semver-major
 
   # Update GitHub Actions
   - package-ecosystem: github-actions


### PR DESCRIPTION
## Summary

Parks major-version updates for jsdom and global-jsdom in Dependabot config.

The two are version-coupled (global-jsdom 26 targets jsdom 26), and Dependabot's separate major PRs cannot resolve against each other: global-jsdom 29 requires jsdom >=29 <30 while the jsdom PR offers 30, so both fail CI on a peer conflict. On top of that, global-jsdom carries a patch-package patch tied to major 26 that would need regenerating. Rather than leave two permanently-red PRs open, this defers the whole coordinated migration and stops the noise.

The deferred migration is tracked in [AHWR-2232](https://eaflood.atlassian.net/browse/AHWR-2232), which covers bumping the pair to a compatible set, regenerating or dropping the patch, and removing these ignores.

## What Changed

- Added `jsdom` and `global-jsdom` to the npm `ignore` list in `.github/dependabot.yml`, restricted to `version-update:semver-major`.

## Why

Bumping either package's major requires picking a compatible jsdom/global-jsdom pair together and regenerating the patch-package patch - a coordinated piece of work, not a mergeable Dependabot PR. Ignoring only the majors leaves minor and patch updates flowing (so the pair stays current within major 26) while closing the two failing major PRs and preventing new ones. The in-file comment records the deferred migration, and [AHWR-2232](https://eaflood.atlassian.net/browse/AHWR-2232) carries the full plan for whoever picks it up.

[AHWR-2232]: https://eaflood.atlassian.net/browse/AHWR-2232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AHWR-2232]: https://eaflood.atlassian.net/browse/AHWR-2232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ