### PR TITLE
chore(deps): (AHWR-2118) ignore ioredis and catbox-memory majors #patch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -64,6 +64,14 @@ updates:
       - dependency-name: global-jsdom
         update-types:
           - version-update:semver-major
+      # ioredis pinned to 5.x: @hapi/catbox-redis 7.0.2 peers ioredis ^5; revisit when catbox-redis accepts ^6
+      - dependency-name: ioredis
+        update-types:
+          - version-update:semver-major
+      # @hapi/catbox-memory pinned to 5.x: 6 trips a @hapi/validate error-annotation bug in the select-herd tests (public-ui only); revisit once @hapi/hapi ships a fixed @hapi/validate
+      - dependency-name: "@hapi/catbox-memory"
+        update-types:
+          - version-update:semver-major
 
   # Update GitHub Actions
   - package-ecosystem: github-actions


### PR DESCRIPTION
## Summary

Parks major-version updates for ioredis and @hapi/catbox-memory in Dependabot config, blocking their major bumps while leaving minor and patch updates flowing. Both majors are currently unmergeable, for different reasons, and this stops Dependabot repeatedly raising PRs that cannot go in. Config only - no runtime, test, or build impact. Each block has a follow-up ticket for the deliberate upgrade once it is unblocked.

## What Changed

- Added an `ignore` entry for `ioredis`, scoped to `version-update:semver-major`.
- Added an `ignore` entry for `@hapi/catbox-memory`, scoped to `version-update:semver-major`.
- Each carries an inline comment recording its specific blocking condition.

## Why

Two separate blocks, both parked rather than forced, each tracked for follow-up:

- ioredis 6 is blocked upstream: @hapi/catbox-redis 7.0.2 peers `ioredis ^5`, so bumping to 6 would run an unsupported client/cache pairing against the production Redis session store. Revisit when catbox-redis accepts ^6. This mirrors the same park already applied in ahwr-backoffice-ui, and the deliberate upgrade (both UIs) is tracked in [AHWR-2239](https://eaflood.atlassian.net/browse/AHWR-2239).
- @hapi/catbox-memory 6 fails CI here with a @hapi/validate error-annotation bug (`refAnnotations.errors[cacheKey].push is not a function`) in the select-herd validation tests - a public-ui-specific transitive interaction, not a catbox-memory API break (backoffice runs 6.0.2 fine). Revisit once @hapi/hapi ships a fixed @hapi/validate. Tracked in [AHWR-2240](https://eaflood.atlassian.net/browse/AHWR-2240).

A config-level ignore keeps the blocking condition visible and auditable in the repo, and mirrors the existing global-agent, jsdom/global-jsdom, ioredis (backoffice) and sass-loader ignore idioms. Both packages stay current on their 5.x lines via minor and patch updates.

[AHWR-2239]: https://eaflood.atlassian.net/browse/AHWR-2239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ